### PR TITLE
Add a slash between shotener url and shoten note url.

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -116,7 +116,7 @@ class Note < Content
 
   def short_link
     path = redirect.from_path
-    "#{prefix} #{path}"
+    "#{prefix}/#{path}"
   end
 
   def prefix

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -40,12 +40,12 @@ describe Note, type: :model do
 
         context 'with a blog that have a custome url shortener' do
           let(:url_shortener) { 'shor.tl' }
-          it { expect(note.short_link).to eq("#{url_shortener} #{note.redirect.from_path}") }
+          it { expect(note.short_link).to eq("#{url_shortener}/#{note.redirect.from_path}") }
         end
 
         context 'with a blog that does not have a custome url shortener' do
           let(:url_shortener) { nil }
-          it { expect(note.short_link).to eq("mybaseurl.net #{note.redirect.from_path}") }
+          it { expect(note.short_link).to eq("mybaseurl.net/#{note.redirect.from_path}") }
         end
       end
     end


### PR DESCRIPTION
A short url at Twitter doesn't work well. Because, it isn't concatenated with a slash between urls.
So, I wish "Add a slash".

present
```
Update Publify to 9.0.0! (http://coapublify.herokuapp.com  6kM14T)
```

wish
```
Update Publify to 9.0.0!  (http://coapublify.herokuapp.com/6kM14T)
```