### PR TITLE
Remove obsolete Sidebar code

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -13,9 +13,6 @@ class BaseController < ApplicationController
 
   def set_paths
     prepend_view_path this_blog.current_theme.view_path
-    Dir.glob(File.join(::Rails.root.to_s, "lib", "*_sidebar/app/views")).select do |file|
-      append_view_path file
-    end
   end
 
   def fire_triggers

--- a/lib/sidebar_registry.rb
+++ b/lib/sidebar_registry.rb
@@ -14,18 +14,6 @@ class SidebarRegistry
       registered_sidebars.sort
     end
 
-    def register_sidebar_directory(plugins_root, paths)
-      separator = plugins_root.include?("/") ? "/" : "\\"
-
-      Dir.glob(File.join(plugins_root, "*_sidebar")).select do |file|
-        plugin_name = file.split(separator).last
-        register_sidebar plugin_name.classify
-        # TODO: Move Sidebars to app/models, and views to app/views so this can
-        # be simplified.
-        paths << File.join(plugins_root, plugin_name, "lib")
-      end
-    end
-
     private
 
     def registered_sidebars


### PR DESCRIPTION
- Remove obsolete method `SidebarRegistry.register_sidebar_directory`
- Remove obsolete sidebar view path registration
