### PR TITLE
Replace MiniTest assertions with expect syntax

### DIFF
--- a/spec/controllers/admin/articles_controller_spec.rb
+++ b/spec/controllers/admin/articles_controller_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Admin::ArticlesController, type: :controller do
         post :create,
              params: { article: { title: "another test", body: body, extended: extended } }
 
-        assert_response :redirect, action: "index"
+        expect(response).to redirect_to action: "index"
 
         new_article = Article.order(created_at: :desc).first
 
@@ -393,7 +393,7 @@ RSpec.describe Admin::ArticlesController, type: :controller do
         body = "another *markdown* test"
         put :update, params: { id: art_id,
                                article: { body: body, text_filter_name: "markdown" } }
-        assert_response :redirect, action: "show", id: art_id
+        expect(response).to redirect_to action: "index"
 
         article.reload
         expect(article.text_filter.name).to eq("markdown")
@@ -406,7 +406,7 @@ RSpec.describe Admin::ArticlesController, type: :controller do
         put :update, params: { "id" => article.id, "article" => {
           "body_and_extended" => "foo<!--more-->bar<!--more-->baz",
         } }
-        assert_response :redirect
+        expect(response).to redirect_to action: "index"
         article.reload
         expect(article.body).to eq("foo")
         expect(article.extended).to eq("bar<!--more-->baz")
@@ -416,7 +416,7 @@ RSpec.describe Admin::ArticlesController, type: :controller do
         put :update, params: { "id" => article.id, "article" => {
           "password" => "foobar",
         } }
-        assert_response :redirect
+        expect(response).to redirect_to action: "index"
         article.reload
         expect(article.password).to eq("foobar")
       end

--- a/spec/controllers/admin/articles_controller_spec.rb
+++ b/spec/controllers/admin/articles_controller_spec.rb
@@ -164,14 +164,14 @@ RSpec.describe Admin::ArticlesController, type: :controller do
 
         post :create, params: { "article" => base_article }
 
-        assert_equal(1, emails.size)
-        assert_equal(u.email, emails.first.to[0])
+        expect(emails.size).to eq 1
+        expect(emails.first.to[0]).to eq u.email
       end
 
       it "creates an article with tags" do
         post :create, params: { "article" => base_article(keywords: "foo bar") }
         new_article = Article.last
-        assert_equal 2, new_article.tags.size
+        expect(new_article.tags.size).to eq 2
       end
 
       it "creates an article with a password" do
@@ -190,14 +190,14 @@ RSpec.describe Admin::ArticlesController, type: :controller do
         article = base_article(published_at: "February 17, 2011 08:47 PM GMT+0100 (CET)")
         post :create, params: { article: article }
         new_article = Article.last
-        assert_equal Time.utc(2011, 2, 17, 19, 47), new_article.published_at
+        expect(new_article.published_at).to eq Time.utc(2011, 2, 17, 19, 47)
       end
 
       it 'respects "GMT+0000 (UTC)" in :published_at' do
         article = base_article(published_at: "August 23, 2011 08:40 PM GMT+0000 (UTC)")
         post :create, params: { article: article }
         new_article = Article.last
-        assert_equal Time.utc(2011, 8, 23, 20, 40), new_article.published_at
+        expect(new_article.published_at).to eq Time.utc(2011, 8, 23, 20, 40)
       end
 
       it "creates a filtered article" do

--- a/spec/controllers/admin/articles_controller_spec.rb
+++ b/spec/controllers/admin/articles_controller_spec.rb
@@ -440,12 +440,9 @@ RSpec.describe Admin::ArticlesController, type: :controller do
           end
 
           it "deletes all drafts" do
-            assert_raises ActiveRecord::RecordNotFound do
-              Article.find(draft.id)
-            end
-            assert_raises ActiveRecord::RecordNotFound do
-              Article.find(second_draft.id)
-            end
+            expect { Article.find(draft.id) }.to raise_error ActiveRecord::RecordNotFound
+            expect { Article.find(second_draft.id) }.
+              to raise_error ActiveRecord::RecordNotFound
           end
 
           it "keeps the original publication date" do
@@ -466,12 +463,9 @@ RSpec.describe Admin::ArticlesController, type: :controller do
           end
 
           it "deletes all drafts" do
-            assert_raises ActiveRecord::RecordNotFound do
-              Article.find(draft.id)
-            end
-            assert_raises ActiveRecord::RecordNotFound do
-              Article.find(second_draft.id)
-            end
+            expect { Article.find(draft.id) }.to raise_error ActiveRecord::RecordNotFound
+            expect { Article.find(second_draft.id) }.
+              to raise_error ActiveRecord::RecordNotFound
           end
 
           it "keeps the original publication date" do

--- a/spec/controllers/admin/post_types_controller_spec.rb
+++ b/spec/controllers/admin/post_types_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Admin::PostTypesController, type: :controller do
     it "updates a post_type and redirect to #index" do
       @test_id = create(:post_type).id
       post :update, params: { id: @test_id, post_type: { name: "another name" } }
-      assert_response :redirect, action: "index"
+      expect(response).to redirect_to action: "index"
       expect(PostType.count).to eq(1)
       expect(PostType.first.name).to eq("another name")
     end

--- a/spec/controllers/admin/redirects_controller_spec.rb
+++ b/spec/controllers/admin/redirects_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Admin::RedirectsController, type: :controller do
       expect do
         post :create, params: { "redirect" => { from_path: "some/place",
                                                 to_path: "somewhere/else" } }
-        assert_response :redirect, action: "index"
+        expect(response).to redirect_to action: "index"
       end.to change(Redirect, :count)
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Admin::RedirectsController, type: :controller do
       expect do
         post :create, params: { "redirect" => { from_path: "",
                                                 to_path: "somewhere/different" } }
-        assert_response :redirect, action: "index"
+        expect(response).to redirect_to action: "index"
       end.to change(Redirect, :count)
     end
   end
@@ -77,7 +77,7 @@ RSpec.describe Admin::RedirectsController, type: :controller do
       @test_id = create(:redirect).id
       post :update, params: { id: @test_id, redirect: { from_path: "somewhere/over",
                                                         to_path: "the/rainbow" } }
-      assert_response :redirect, action: "index"
+      expect(response).to redirect_to action: "index"
       expect(Redirect.count).to eq(1)
       expect(Redirect.first.from_path).to eq("somewhere/over")
       expect(Redirect.first.to_path).to eq("the/rainbow")
@@ -92,7 +92,7 @@ RSpec.describe Admin::RedirectsController, type: :controller do
 
     it "redirects to index" do
       post :destroy, params: { id: @test_id }
-      assert_response :redirect, action: "index"
+      expect(response).to redirect_to action: "index"
     end
 
     it "noes longer exist" do

--- a/spec/controllers/admin/resources_controller_spec.rb
+++ b/spec/controllers/admin/resources_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Admin::ResourcesController, type: :controller do
     end
 
     it "renders index template" do
-      assert_response :success
+      expect(response).to be_successful
       assert_template "index"
       expect(assigns(:resources)).not_to be_nil
     end

--- a/spec/controllers/admin/resources_controller_spec.rb
+++ b/spec/controllers/admin/resources_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Admin::ResourcesController, type: :controller do
 
     it "renders index template" do
       expect(response).to be_successful
-      assert_template "index"
+      expect(response).to render_template "index"
       expect(assigns(:resources)).not_to be_nil
     end
   end

--- a/spec/controllers/admin/sidebar_controller_spec.rb
+++ b/spec/controllers/admin/sidebar_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Admin::SidebarController, type: :controller do
 
       it "renders the sidebar configuration" do
         get :index
-        assert_template "index"
+        expect(response).to render_template "index"
         assert_select "div#sidebar-config"
       end
     end

--- a/spec/controllers/admin/sidebar_controller_spec.rb
+++ b/spec/controllers/admin/sidebar_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Admin::SidebarController, type: :controller do
       it "renders the sidebar configuration" do
         get :index
         expect(response).to render_template "index"
-        assert_select "div#sidebar-config"
+        expect(response.body).to have_css "div#sidebar-config"
       end
     end
   end

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Admin::TagsController, type: :controller do
     it "updates a tag and redirect to #index" do
       @test_id = create(:tag).id
       post :update, params: { id: @test_id, tag: { display_name: "another_name" } }
-      assert_response :redirect, action: "index"
+      expect(response).to redirect_to action: "index"
       expect(Tag.count).to eq(1)
       expect(Tag.find(@test_id).display_name).to eq("another_name")
     end

--- a/spec/controllers/admin/themes_controller_spec.rb
+++ b/spec/controllers/admin/themes_controller_spec.rb
@@ -17,18 +17,18 @@ RSpec.describe Admin::ThemesController, type: :controller do
     end
 
     it "assigns @themes for the :index action" do
-      assert_response :success
+      expect(response).to be_successful
       expect(assigns(:themes)).not_to be_nil
     end
   end
 
   it "redirects to :index after the :switchto action" do
     post :switchto, params: { theme: "typographic" }
-    assert_response :redirect, action: "index"
+    expect(response).to redirect_to action: "index"
   end
 
   it "returns success for the :preview action" do
     get :preview, params: { theme: "plain" }
-    assert_response :success
+    expect(response).to be_successful
   end
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     it "renders a list of users" do
       get :index
-      assert_template "index"
+      expect(response).to render_template "index"
       expect(assigns(:users)).not_to be_nil
     end
 
@@ -41,7 +41,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     it "renders the new template" do
       get :new
-      assert_template "new"
+      expect(response).to render_template "new"
     end
   end
 

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -289,21 +289,18 @@ RSpec.describe ArticlesController, type: :controller do
         it "redirects" do
           create(:redirect, from_path: "foo/bar", to_path: "/someplace/else")
           get :redirect, params: { from: "foo/bar" }
-          assert_response 301
           expect(response).to redirect_to("http://test.host/blog/someplace/else")
         end
 
         it "redirects if to_path includes relative_url_root" do
           create(:redirect, from_path: "bar/foo", to_path: "/blog/someplace/else")
           get :redirect, params: { from: "bar/foo" }
-          assert_response 301
           expect(response).to redirect_to("http://test.host/blog/someplace/else")
         end
 
         it "ignores the blog base_url if the to_path is a full uri" do
           create(:redirect, from_path: "foo", to_path: "http://some.where/else")
           get :redirect, params: { from: "foo" }
-          assert_response 301
           expect(response).to redirect_to("http://some.where/else")
         end
       end
@@ -348,7 +345,6 @@ RSpec.describe ArticlesController, type: :controller do
         article = create(:article, permalink: "second-blog-article",
                                    published_at: Time.utc(2004, 4, 1))
         get :redirect, params: { from: "articles/2004/04/01/second-blog-article" }
-        assert_response 301
         expect(response).to redirect_to article.permalink_url
       end
 
@@ -357,7 +353,6 @@ RSpec.describe ArticlesController, type: :controller do
         create(:article, permalink: "second-blog-article", published_at: Time.utc(2004, 4,
                                                                                   1))
         get :redirect, params: { from: "articles/2004/04/01/second-blog-article" }
-        assert_response 301
         expect(response).
           to redirect_to("http://test.host/blog/2004/04/01/second-blog-article")
       end
@@ -367,7 +362,6 @@ RSpec.describe ArticlesController, type: :controller do
         create(:article, permalink: "second-blog-article", published_at: Time.utc(2004, 4,
                                                                                   1))
         get :redirect, params: { from: "articles/2004/04/01/second-blog-article" }
-        assert_response 301
         expect(response).
           to redirect_to("http://test.host/aaa/articles/bbb/2004/04/01/second-blog-article")
       end

--- a/spec/controllers/theme_controller_spec.rb
+++ b/spec/controllers/theme_controller_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe ThemeController, type: :controller do
   it "test_stylesheets" do
     get :stylesheets, params: { filename: "theme.css" }
     assert_response :success
-    assert_equal "text/css", @response.media_type
-    assert_equal "utf-8", @response.charset
-    assert_equal 'inline; filename="theme.css"; filename*=UTF-8\'\'theme.css',
-                 @response.headers["Content-Disposition"]
+    expect(@response.media_type).to eq "text/css"
+    expect(@response.charset).to eq "utf-8"
+    expect(@response.headers["Content-Disposition"]).
+      to eq 'inline; filename="theme.css"; filename*=UTF-8\'\'theme.css'
   end
 
   it "test_javascripts" do
     get :javascripts, params: { filename: "theme.js" }
     assert_response :success
-    assert_equal "text/javascript", @response.media_type
-    assert_equal "utf-8", @response.charset
-    assert_equal 'inline; filename="theme.js"; filename*=UTF-8\'\'theme.js',
-                 @response.headers["Content-Disposition"]
+    expect(@response.media_type).to eq "text/javascript"
+    expect(@response.charset).to eq "utf-8"
+    expect(@response.headers["Content-Disposition"]).
+      to eq 'inline; filename="theme.js"; filename*=UTF-8\'\'theme.js'
   end
 
   it "test_malicious_path" do

--- a/spec/controllers/theme_controller_spec.rb
+++ b/spec/controllers/theme_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ThemeController, type: :controller do
 
   it "test_stylesheets" do
     get :stylesheets, params: { filename: "theme.css" }
-    assert_response :success
+    expect(response).to be_successful
     expect(@response.media_type).to eq "text/css"
     expect(@response.charset).to eq "utf-8"
     expect(@response.headers["Content-Disposition"]).
@@ -16,7 +16,7 @@ RSpec.describe ThemeController, type: :controller do
 
   it "test_javascripts" do
     get :javascripts, params: { filename: "theme.js" }
-    assert_response :success
+    expect(response).to be_successful
     expect(@response.media_type).to eq "text/javascript"
     expect(@response.charset).to eq "utf-8"
     expect(@response.headers["Content-Disposition"]).

--- a/spec/controllers/xml_controller_spec.rb
+++ b/spec/controllers/xml_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe XmlController, type: :controller do
     end
 
     it "is succesful" do
-      assert_response :success
+      expect(response).to be_successful
     end
 
     it "includes articles and tags as items" do

--- a/spec/lib/publify_textfilter_markdown_spec.rb
+++ b/spec/lib/publify_textfilter_markdown_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe PublifyApp::Textfilter::Markdown do
 
   it "applies markdown processing to the supplied text" do
     text = filter_text("*foo*")
-    assert_equal "<p><em>foo</em></p>", text
+    expect(text).to eq "<p><em>foo</em></p>"
 
     text = filter_text("foo\n\nbar")
-    assert_equal "<p>foo</p>\n<p>bar</p>", text
+    expect(text).to eq "<p>foo</p>\n<p>bar</p>"
   end
 
   it "does not apply smart quoting to the supplied text" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Article, type: :model do
     a.user_id = 1
     a.body = "Foo"
     a.title = "Zzz"
-    assert a.save
+    a.save!
 
     a.tags << Tag.find(create(:tag).id)
     expect(a.tags.size).to eq 1
@@ -258,13 +258,13 @@ RSpec.describe Article, type: :model do
     expect(art).to be_publication_pending
 
     expect(Trigger.count).to eq 1
-    assert Trigger.where(pending_item_id: art.id).first
-    assert !art.published?
+    expect(Trigger.where(pending_item_id: art.id).first).not_to be_nil
+    expect(art).not_to be_published
     Timecop.freeze(4.seconds.from_now) do
       Trigger.fire
     end
     art.reload
-    assert art.published?
+    expect(art).to be_published
   end
 
   it "test_triggers_are_dependent" do
@@ -302,14 +302,14 @@ RSpec.describe Article, type: :model do
 
   it "test_withdrawal" do
     art = create(:article)
-    assert art.published?
-    assert !art.withdrawn?
+    expect(art).to be_published
+    expect(art).not_to be_withdrawn
     art.withdraw!
-    assert !art.published?
-    assert art.withdrawn?
+    expect(art).not_to be_published
+    expect(art).to be_withdrawn
     art.reload
-    assert !art.published?
-    assert art.withdrawn?
+    expect(art).not_to be_published
+    expect(art).to be_withdrawn
   end
 
   it "gets only ham not spam comment" do
@@ -970,23 +970,23 @@ RSpec.describe Article, type: :model do
 
       it "does not allow comments for a draft article" do
         art = build :article, state: "draft", blog: blog
-        assert art.comments_closed?
+        expect(art).to be_comments_closed
       end
 
       it "does not allow comments for an article that will be published in the future" do
         art = build :article, state: "publication_pending",
                               published_at: 1.day.from_now, blog: blog
-        assert art.comments_closed?
+        expect(art).to be_comments_closed
       end
 
       it "allows comments for a newly published article" do
         art = build :article, published_at: 1.second.ago, blog: blog
-        assert !art.comments_closed?
+        expect(art).not_to be_comments_closed
       end
 
       it "allows comments for a very old article" do
         art = build :article, created_at: 1000.days.ago, blog: blog
-        assert !art.comments_closed?
+        expect(art).not_to be_comments_closed
       end
     end
 
@@ -995,12 +995,12 @@ RSpec.describe Article, type: :model do
 
       it "allows comments for a recently published article" do
         art = build :article, published_at: 29.days.ago, blog: blog
-        assert !art.comments_closed?
+        expect(art).not_to be_comments_closed
       end
 
       it "does not allow comments for an old article" do
         art = build :article, published_at: 31.days.ago, blog: blog
-        assert art.comments_closed?
+        expect(art).to be_comments_closed
       end
     end
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Article, type: :model do
 
   it "test_content_fields" do
     a = blog.articles.build
-    assert_equal [:body, :extended], a.content_fields
+    expect(a.content_fields).to eq [:body, :extended]
   end
 
   describe "#permalink_url" do
@@ -115,29 +115,30 @@ RSpec.describe Article, type: :model do
     assert a.save
 
     a.tags << Tag.find(create(:tag).id)
-    assert_equal 1, a.tags.size
+    expect(a.tags.size).to eq 1
 
     b = described_class.find(a.id)
-    assert_equal 1, b.tags.size
+    expect(b.tags.size).to eq 1
   end
 
   it "test_permalink_with_title" do
     article = create(:article, permalink: "article-3", published_at: Time.utc(2004, 6, 1))
-    assert_equal(article, described_class.requested_article(year: 2004, month: 6, day: 1,
-                                                            title: "article-3"))
+    found = described_class.requested_article(year: 2004, month: 6, day: 1,
+                                              title: "article-3")
+    expect(found).to eq article
     not_found = described_class.requested_article year: 2005, month: "06", day: "01",
                                                   title: "article-5"
     expect(not_found).to be_nil
   end
 
   it "test_strip_title" do
-    assert_equal "article-3", "Article-3".to_url
-    assert_equal "article-3", "Article 3!?#".to_url
-    assert_equal "there-is-sex-in-my-violence", "There is Sex in my Violence!".to_url
-    assert_equal "article", "-article-".to_url
-    assert_equal "lorem-ipsum-dolor-sit-amet-consectetaur-adipisicing-elit",
-                 "Lorem ipsum dolor sit amet, consectetaur adipisicing elit".to_url
-    assert_equal "my-cats-best-friend", "My Cat's Best Friend".to_url
+    expect("Article-3".to_url).to eq "article-3"
+    expect("Article 3!?#".to_url).to eq "article-3"
+    expect("There is Sex in my Violence!".to_url).to eq "there-is-sex-in-my-violence"
+    expect("-article-".to_url).to eq "article"
+    expect("Lorem ipsum dolor sit amet, consectetaur adipisicing elit".to_url).
+      to eq "lorem-ipsum-dolor-sit-amet-consectetaur-adipisicing-elit"
+    expect("My Cat's Best Friend".to_url).to eq "my-cats-best-friend"
   end
 
   describe "#set_permalink" do
@@ -150,7 +151,7 @@ RSpec.describe Article, type: :model do
     it "strips html" do
       a = blog.articles.build(title: "This <i>is</i> a <b>test</b>", state: :published)
       a.set_permalink
-      assert_equal "this-is-a-test", a.permalink
+      expect(a.permalink).to eq "this-is-a-test"
     end
 
     it "does not escape multibyte characters" do
@@ -185,31 +186,31 @@ RSpec.describe Article, type: :model do
     it "extracts URLs from the generated body html" do
       @article.body = 'happy halloween <a href="http://www.example.com/public">with</a>'
       urls = @article.html_urls
-      assert_equal ["http://www.example.com/public"], urls
+      expect(urls).to eq ["http://www.example.com/public"]
     end
 
     it "onlies match the href attribute" do
       @article.body = '<a href="http://a/b">a</a> <a fhref="wrong">wrong</a>'
       urls = @article.html_urls
-      assert_equal ["http://a/b"], urls
+      expect(urls).to eq ["http://a/b"]
     end
 
     it "matches across newlines" do
       @article.body = "<a\nhref=\"http://foo/bar\">foo</a>"
       urls = @article.html_urls
-      assert_equal ["http://foo/bar"], urls
+      expect(urls).to eq ["http://foo/bar"]
     end
 
     it "matches with single quotes" do
       @article.body = "<a href='http://foo/bar'>foo</a>"
       urls = @article.html_urls
-      assert_equal ["http://foo/bar"], urls
+      expect(urls).to eq ["http://foo/bar"]
     end
 
     it "matches with no quotes" do
       @article.body = "<a href=http://foo/bar>foo</a>"
       urls = @article.html_urls
-      assert_equal ["http://foo/bar"], urls
+      expect(urls).to eq ["http://foo/bar"]
     end
   end
 
@@ -246,7 +247,7 @@ RSpec.describe Article, type: :model do
     art2 = create(:article)
     create(:tag, name: "foo", contents: [art1, art2])
     articles = Tag.find_by(name: "foo").published_contents
-    assert_equal 2, articles.size
+    expect(articles.size).to eq 2
   end
 
   it "test_future_publishing" do
@@ -256,7 +257,7 @@ RSpec.describe Article, type: :model do
 
     expect(art).to be_publication_pending
 
-    assert_equal 1, Trigger.count
+    expect(Trigger.count).to eq 1
     assert Trigger.where(pending_item_id: art.id).first
     assert !art.published?
     Timecop.freeze(4.seconds.from_now) do
@@ -272,20 +273,20 @@ RSpec.describe Article, type: :model do
     skip
     art = blog.articles.create!(title: "title", body: "body",
                                 published_at: 1.hour.from_now)
-    assert_equal 1, Trigger.count
+    expect(Trigger.count).to eq 1
     art.destroy
-    assert_equal 0, Trigger.count
+    expect(Trigger.count).to eq 0
   end
 
   it "test_destroy_file_upload_associations" do
     a = create(:article)
     create(:resource, content: a)
     create(:resource, content: a)
-    assert_equal 2, a.resources.size
+    expect(a.resources.size).to eq 2
     a.resources << create(:resource)
-    assert_equal 3, a.resources.size
+    expect(a.resources.size).to eq 3
     a.destroy
-    assert_equal 0, Resource.where(content_id: a.id).size
+    expect(Resource.where(content_id: a.id).size).to eq 0
   end
 
   describe "#interested_users" do
@@ -357,7 +358,7 @@ RSpec.describe Article, type: :model do
       it "has two items" do
         create(:article, extended: "extended talk")
         create(:article, extended: "Once uppon a time, an extended story")
-        assert_equal 2, described_class.search("extended").size
+        expect(described_class.search("extended").size).to eq 2
       end
     end
   end
@@ -429,28 +430,28 @@ RSpec.describe Article, type: :model do
 
     it "returns false for a fresh article if it allows pings" do
       a = create(:article, allow_pings: true)
-      assert_equal(false, a.pings_closed?)
+      expect(a.pings_closed?).to be false
     end
 
     it "returns true for a fresh article if it does not allow pings" do
       a = create(:article, allow_pings: false)
-      assert_equal(true, a.pings_closed?)
+      expect(a.pings_closed?).to be true
     end
 
     it "returns true for an old article even if it allows pings" do
       a = create(:article, published_at: 31.days.ago, allow_pings: true)
-      assert_equal(true, a.pings_closed?)
+      expect(a.pings_closed?).to be true
     end
 
     it "returns true for a draft article even if it allows pings" do
       a = create(:article, state: "draft", allow_pings: true)
-      assert_equal(true, a.pings_closed?)
+      expect(a.pings_closed?).to be true
     end
 
     it "returns true for a pending article even if it allows pings" do
       a = create(:article, state: "publication_pending", published_at: 1.day.from_now,
                            allow_pings: true)
-      assert_equal(true, a.pings_closed?)
+      expect(a.pings_closed?).to be true
     end
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe Comment, type: :model do
     it "saves good comment" do
       c = build(:comment, url: "http://www.google.de")
       assert c.save
-      assert_equal "http://www.google.de", c.url
+      expect(c.url).to eq "http://www.google.de"
     end
 
     it "saves spam comment" do
       c = build(:comment, body: 'test <a href="http://fakeurl.com">body</a>')
       assert c.save
-      assert_equal "http://fakeurl.com", c.url
+      expect(c.url).to eq "http://fakeurl.com"
     end
 
     it "does not save when article comment window is closed" do
@@ -191,7 +191,7 @@ RSpec.describe Comment, type: :model do
     article = build_stubbed(:article)
     comment = build_stubbed(:comment, article: article)
     assert comment.article
-    assert_equal article, comment.article
+    expect(comment.article).to eq article
   end
 
   describe "change state" do
@@ -215,7 +215,7 @@ RSpec.describe Comment, type: :model do
   it "has good default filter" do
     create :blog, text_filter: "markdown", comment_text_filter: "markdown"
     a = create(:comment)
-    assert_equal "markdown", a.default_text_filter.name
+    expect(a.default_text_filter.name).to eq "markdown"
   end
 
   describe "spam", integration: true do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -45,13 +45,13 @@ RSpec.describe Comment, type: :model do
   describe "#save" do
     it "saves good comment" do
       c = build(:comment, url: "http://www.google.de")
-      assert c.save
+      c.save!
       expect(c.url).to eq "http://www.google.de"
     end
 
     it "saves spam comment" do
       c = build(:comment, body: 'test <a href="http://fakeurl.com">body</a>')
-      assert c.save
+      c.save!
       expect(c.url).to eq "http://fakeurl.com"
     end
 
@@ -66,8 +66,8 @@ RSpec.describe Comment, type: :model do
 
     it "changes old comment" do
       c = build(:comment, body: "Comment body <em>italic</em> <strong>bold</strong>")
-      assert c.save
-      assert c.errors.empty?
+      c.save!
+      expect(c.errors).to be_empty
     end
 
     it "saves a valid comment" do
@@ -84,8 +84,8 @@ RSpec.describe Comment, type: :model do
 
     it "generates guid" do
       c = build :comment, guid: nil
-      assert c.save
-      assert c.guid.size > 15
+      c.save!
+      expect(c.guid.size).to be > 15
     end
 
     it "preserves urls starting with https://" do
@@ -165,9 +165,9 @@ RSpec.describe Comment, type: :model do
 
         comment.classify_content
 
-        assert !comment.published?
-        assert comment.presumed_spam?
-        assert !comment.status_confirmed?
+        expect(comment).not_to be_published
+        expect(comment).to be_presumed_spam
+        expect(comment).not_to be_status_confirmed
       end
 
       it "marks comment from known user as confirmed ham" do
@@ -180,9 +180,9 @@ RSpec.describe Comment, type: :model do
 
         comment.classify_content
 
-        assert comment.published?
-        assert comment.ham?
-        assert comment.status_confirmed?
+        expect(comment).to be_published
+        expect(comment).to be_ham
+        expect(comment).to be_status_confirmed
       end
     end
   end
@@ -190,18 +190,18 @@ RSpec.describe Comment, type: :model do
   it "has good relation" do
     article = build_stubbed(:article)
     comment = build_stubbed(:comment, article: article)
-    assert comment.article
+    expect(comment.article).not_to be_nil
     expect(comment.article).to eq article
   end
 
   describe "change state" do
     it "becomes unpublished if withdrawn" do
       c = build :comment
-      assert c.published?
-      assert c.withdraw!
-      assert !c.published?
-      assert c.spam?
-      assert c.status_confirmed?
+      expect(c).to be_published
+      c.withdraw!
+      expect(c).not_to be_published
+      expect(c).to be_spam
+      expect(c).to be_status_confirmed
     end
 
     it "becomeses confirmed if withdrawn" do
@@ -287,7 +287,7 @@ RSpec.describe Comment, type: :model do
           blog.comment_text_filter = filter
 
           ActiveSupport::Deprecation.silence do
-            assert comment.html(:body).exclude?("<script>")
+            expect(comment.html(:body)).not_to include "<script>"
           end
         end
       end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -141,13 +141,13 @@ RSpec.describe Feedback, type: :model do
           :ham
         end
       end
-      assert @comment.unclassified?
+      expect(@comment).to be_unclassified
       @comment.classify_content
-      assert @comment.published?
+      expect(@comment).to be_published
       @comment.save
       @comment = Comment.find(@comment.id)
       @comment.confirm_classification
-      assert @comment.published?
+      expect(@comment).to be_published
     end
 
     it "test_spam_all_the_way" do
@@ -156,26 +156,26 @@ RSpec.describe Feedback, type: :model do
           :spam
         end
       end
-      assert @comment.unclassified?
+      expect(@comment).to be_unclassified
       @comment.classify_content
-      assert !@comment.published?
-      assert @comment.save
-      assert !@comment.published?
+      expect(@comment).not_to be_published
+      @comment.save!
+      expect(@comment).not_to be_published
       @comment = Comment.find(@comment.id)
       @comment.confirm_classification
-      assert !@comment.published?
+      expect(@comment).not_to be_published
     end
 
     it "test_presumed_spam_marked_as_ham" do
       @comment[:state] = "presumed_spam"
       @comment.mark_as_ham
-      assert @comment.published?
+      expect(@comment).to be_published
     end
 
     it "test_presumed_ham_marked_as_spam" do
       @comment[:state] = "presumed_ham"
       @comment.mark_as_spam
-      assert !@comment.published?
+      expect(@comment).not_to be_published
     end
   end
 


### PR DESCRIPTION
Note that this does not touch the custom assert methods defined in PublifyCore::TestingSupport::FeedAssertions, since those are also used in the main Publify project.

- Replace assert_equals with equivalent expect syntax
- Replace use of plain assert in specs
- Replace assert_response with expect syntax
- Replace assert_template with expect syntax
- Replace assert_raises with expect syntax
- Replace assert_select with expect syntax
