### PR TITLE
Update CarrierWave to version 3.0

### DIFF
--- a/app/uploaders/resource_uploader.rb
+++ b/app/uploaders/resource_uploader.rb
@@ -57,11 +57,9 @@ class ResourceUploader < CarrierWave::Uploader::Base
   end
 
   def check_content_type!(new_file)
-    detected_type = if image? new_file
-                      file_content_content_type(new_file)
-                    else
-                      file_content_type(new_file)
-                    end
+    return unless image? new_file
+
+    detected_type = file_content_content_type(new_file)
     if detected_type != new_file.content_type
       raise CarrierWave::IntegrityError, "has MIME type mismatch"
     end
@@ -71,9 +69,5 @@ class ResourceUploader < CarrierWave::Uploader::Base
 
   def file_content_content_type(new_file)
     Marcel::MimeType.for Pathname.new(new_file.path)
-  end
-
-  def file_content_type(new_file)
-    Marcel::MimeType.for Pathname.new(new_file.path), name: new_file.filename
   end
 end

--- a/publify_core.gemspec
+++ b/publify_core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aasm", "~> 5.0"
   s.add_dependency "akismet", "~> 3.0"
   s.add_dependency "cancancan", "~> 3.0"
-  s.add_dependency "carrierwave", "~> 2.2.1"
+  s.add_dependency "carrierwave", "~> 3.0"
   s.add_dependency "commonmarker", "~> 0.23.2"
   s.add_dependency "devise", ">= 4.8", "< 4.10"
   s.add_dependency "devise-i18n", "~> 1.2"

--- a/spec/controllers/admin/resources_controller_spec.rb
+++ b/spec/controllers/admin/resources_controller_spec.rb
@@ -226,7 +226,8 @@ RSpec.describe Admin::ResourcesController, type: :controller do
         post :upload, params: { upload: upload }
         result = assigns(:up)
         expect(result.errors[:upload])
-          .to contain_exactly("has MIME type mismatch", "can't be blank")
+          .to contain_exactly(%r{You are not allowed to upload text/html files},
+                              "can't be blank")
       end
 
       it "sets the flash to failure" do


### PR DESCRIPTION
- Update carrierwave requirement to ~> 3.0
- Update expected mime type error message
- Rely on CarrierWave to detect non-image content type mismatch
