### PR TITLE
Fix new rubocop-capybara offenses

### DIFF
--- a/publify_core.gemspec
+++ b/publify_core.gemspec
@@ -57,6 +57,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails-controller-testing", "~> 1.0.1"
   s.add_development_dependency "rspec-rails", "~> 6.0"
   s.add_development_dependency "rubocop", "~> 1.56.1"
+  s.add_development_dependency "rubocop-capybara", "~> 2.19.0"
   s.add_development_dependency "rubocop-factory_bot", "~> 2.24.0"
   s.add_development_dependency "rubocop-performance", "~> 1.19.0"
   s.add_development_dependency "rubocop-rails", "~> 2.20.2"

--- a/spec/controllers/admin/articles_controller_spec.rb
+++ b/spec/controllers/admin/articles_controller_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Admin::ArticlesController, type: :controller do
         a = create(:article, keywords: '"foo bar", baz')
         get :edit, params: { id: a.id }
         expect(response.body)
-          .to have_selector("input[id=article_keywords][value='baz, \"foo bar\"']")
+          .to have_css("input[id=article_keywords][value='baz, \"foo bar\"']")
       end
     end
 

--- a/spec/helpers/author_helper_spec.rb
+++ b/spec/helpers/author_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AuthorsHelper, type: :helper do
   describe "display_profile_item" do
     it "displays the item as a list item if show_item is true" do
       item = display_profile_item("my@jabber.org", "Jabber:")
-      expect(item).to have_selector("li", text: "Jabber: my@jabber.org")
+      expect(item).to have_css("li", text: "Jabber: my@jabber.org")
     end
 
     it "does not display the item empty" do
@@ -16,7 +16,7 @@ RSpec.describe AuthorsHelper, type: :helper do
 
     it "displays a link if the item is an url" do
       item = display_profile_item("http://twitter.com/mytwitter", "Twitter:")
-      expect(item).to have_selector("li") do
+      expect(item).to have_css("li") do
         have_link("http://twitter.com/mytwitter")
       end
     end


### PR DESCRIPTION
- Explicitly specify required rubocop-capybara version
- Autocorrect Capybara/RSpec/HaveSelector offenses
