### PR TITLE
Make it easier to create text filter plugins

### DIFF
--- a/lib/publify_core/text_filter/markdown.rb
+++ b/lib/publify_core/text_filter/markdown.rb
@@ -4,7 +4,9 @@ require "text_filter_plugin"
 require "commonmarker"
 
 module PublifyCore::TextFilter
-  class Markdown < TextFilterPlugin::Markup
+  class Markdown < TextFilterPlugin
+    include TextFilterPlugin::Markup
+
     plugin_display_name "Markdown"
     plugin_description "Markdown markup language from" \
                        ' <a href="http://daringfireball.com/">Daring Fireball</a>'

--- a/lib/publify_core/text_filter/none.rb
+++ b/lib/publify_core/text_filter/none.rb
@@ -3,7 +3,9 @@
 require "text_filter_plugin"
 
 module PublifyCore::TextFilter
-  class None < TextFilterPlugin::Markup
+  class None < TextFilterPlugin
+    include TextFilterPlugin::Markup
+
     plugin_display_name "None"
     plugin_description "Raw HTML only"
 

--- a/lib/publify_core/text_filter/smartypants.rb
+++ b/lib/publify_core/text_filter/smartypants.rb
@@ -3,7 +3,9 @@
 require "rubypants"
 
 module PublifyCore::TextFilter
-  class Smartypants < TextFilterPlugin::PostProcess
+  class Smartypants < TextFilterPlugin
+    include TextFilterPlugin::PostProcess
+
     plugin_display_name "Smartypants"
     plugin_description "Converts HTML to use typographically correct quotes and dashes"
 

--- a/lib/publify_core/text_filter/twitterfilter.rb
+++ b/lib/publify_core/text_filter/twitterfilter.rb
@@ -5,7 +5,9 @@ require "html/pipeline"
 require "html/pipeline/hashtag/hashtag_filter"
 
 module PublifyCore::TextFilter
-  class Twitterfilter < TextFilterPlugin::PostProcess
+  class Twitterfilter < TextFilterPlugin
+    include TextFilterPlugin::PostProcess
+
     plugin_display_name "HTML Filter"
     plugin_description "Strip HTML tags"
 

--- a/lib/text_filter_plugin.rb
+++ b/lib/text_filter_plugin.rb
@@ -13,10 +13,8 @@ class TextFilterPlugin
   def self.inherited(sub)
     super
 
-    if sub.to_s.start_with?("Plugin", "PublifyCore::TextFilter")
-      name = sub.short_name
-      @@filter_map[name] = sub
-    end
+    name = sub.short_name
+    @@filter_map[name] = sub
   end
 
   def self.filter_map

--- a/lib/text_filter_plugin.rb
+++ b/lib/text_filter_plugin.rb
@@ -118,16 +118,16 @@ class TextFilterPlugin
   end
 end
 
-class TextFilterPlugin::PostProcess < TextFilterPlugin
+module TextFilterPlugin::PostProcess
   def self.filter_type
     "postprocess"
   end
 end
 
-class TextFilterPlugin::Macro < TextFilterPlugin
+module TextFilterPlugin::MacroMethods
   # Utility function -- hand it a XML string like <a href="foo" title="bar">
   # and it'll give you back { "href" => "foo", "title" => "bar" }
-  def self.attributes_parse(string)
+  def attributes_parse(string)
     attributes = {}
 
     string.gsub(/([^ =]+="[^"]*")/) do |match|
@@ -143,7 +143,7 @@ class TextFilterPlugin::Macro < TextFilterPlugin
     attributes
   end
 
-  def self.filtertext(text)
+  def filtertext(text)
     regex1 = %r{<publify:#{short_name}(?:[ \t][^>]*)?/>}
     regex2 = %r{<publify:#{short_name}([ \t][^>]*)?>(.*?)</publify:#{short_name}>}m
 
@@ -157,20 +157,40 @@ class TextFilterPlugin::Macro < TextFilterPlugin
   end
 end
 
-class TextFilterPlugin::MacroPre < TextFilterPlugin::Macro
-  def self.filter_type
-    "macropre"
+module TextFilterPlugin::MacroPre
+  def self.included(base)
+    base.extend ClassMethods
+    base.extend TextFilterPlugin::MacroMethods
+  end
+
+  module ClassMethods
+    def filter_type
+      "macropre"
+    end
   end
 end
 
-class TextFilterPlugin::MacroPost < TextFilterPlugin::Macro
-  def self.filter_type
-    "macropost"
+module TextFilterPlugin::MacroPost
+  def self.included(base)
+    base.extend ClassMethods
+    base.extend TextFilterPlugin::MacroMethods
+  end
+
+  module ClassMethods
+    def filter_type
+      "macropost"
+    end
   end
 end
 
-class TextFilterPlugin::Markup < TextFilterPlugin
-  def self.filter_type
-    "markup"
+module TextFilterPlugin::Markup
+  def self.included(base)
+    base.extend ClassMethods
+  end
+
+  module ClassMethods
+    def filter_type
+      "markup"
+    end
   end
 end

--- a/spec/lib/text_filter_plugin_spec.rb
+++ b/spec/lib/text_filter_plugin_spec.rb
@@ -20,17 +20,51 @@ RSpec.describe TextFilterPlugin do
     end
   end
 
-  describe described_class::Macro do
-    describe "#self.attributes_parse" do
+  shared_examples "a macro module" do
+    describe ".attributes_parse" do
       it 'parses lang="ruby" to {"lang" => "ruby"}' do
-        expect(described_class.attributes_parse('<publify:code lang="ruby">'))
+        expect(derived_class.attributes_parse('<publify:code lang="ruby">'))
           .to eq("lang" => "ruby")
       end
 
       it "parses lang='ruby' to {'lang' => 'ruby'}" do
-        expect(described_class.attributes_parse("<publify:code lang='ruby'>"))
+        expect(derived_class.attributes_parse("<publify:code lang='ruby'>"))
           .to eq("lang" => "ruby")
       end
+    end
+  end
+
+  describe described_class::MacroPre, "when included" do
+    let(:derived_class) do
+      Class.new.tap { |klass| klass.include described_class }
+    end
+
+    it_behaves_like "a macro module"
+
+    it "declares including classes to be macropre filters" do
+      expect(derived_class.filter_type).to eq "macropre"
+    end
+  end
+
+  describe described_class::MacroPost, "when included" do
+    let(:derived_class) do
+      Class.new.tap { |klass| klass.include described_class }
+    end
+
+    it_behaves_like "a macro module"
+
+    it "declares including classes to be macropost filters" do
+      expect(derived_class.filter_type).to eq "macropost"
+    end
+  end
+
+  describe described_class::Markup, "when included" do
+    let(:derived_class) do
+      Class.new.tap { |klass| klass.include described_class }
+    end
+
+    it "declares including classes to be markup filters" do
+      expect(derived_class.filter_type).to eq "markup"
     end
   end
 end

--- a/spec/lib/text_filter_plugin_spec.rb
+++ b/spec/lib/text_filter_plugin_spec.rb
@@ -4,27 +4,20 @@ require "rails_helper"
 
 RSpec.describe TextFilterPlugin do
   describe ".available_filters" do
-    subject { described_class.available_filters }
-
-    it { is_expected.to include(PublifyCore::TextFilter::Markdown) }
-    it { is_expected.to include(PublifyCore::TextFilter::Smartypants) }
-    it { is_expected.to include(PublifyCore::TextFilter::Twitterfilter) }
-    it { is_expected.not_to include(TextFilterPlugin::Markup) }
-    it { is_expected.not_to include(TextFilterPlugin::Macro) }
-    it { is_expected.not_to include(TextFilterPlugin::MacroPre) }
-    it { is_expected.not_to include(TextFilterPlugin::MacroPost) }
+    it "lists only directly usable filters" do
+      expect(described_class.available_filters).to contain_exactly(
+        PublifyCore::TextFilter::None,
+        PublifyCore::TextFilter::Markdown,
+        PublifyCore::TextFilter::Smartypants,
+        PublifyCore::TextFilter::MarkdownSmartquotes,
+        PublifyCore::TextFilter::Twitterfilter)
+    end
   end
 
   describe ".macro_filters" do
-    subject { described_class.macro_filters }
-
-    it { is_expected.not_to include(PublifyCore::TextFilter::Markdown) }
-    it { is_expected.not_to include(PublifyCore::TextFilter::Smartypants) }
-    it { is_expected.not_to include(PublifyCore::TextFilter::Twitterfilter) }
-    it { is_expected.not_to include(TextFilterPlugin::Markup) }
-    it { is_expected.not_to include(TextFilterPlugin::Macro) }
-    it { is_expected.not_to include(TextFilterPlugin::MacroPre) }
-    it { is_expected.not_to include(TextFilterPlugin::MacroPost) }
+    it "lists no filters" do
+      expect(described_class.macro_filters).to be_empty
+    end
   end
 
   describe described_class::Macro do


### PR DESCRIPTION
This change mainly removes the requirement that text filter plugins must either have a name starting with plugin or be in a particular namespace.

In exchange, plugins that previously subclassed MacroPre, MacroPost, PostProcess or Markup now should include the module of the same name and subclass TextFilterPlugin.

- Simplify test for TextFilterPlugin filter list methods
- Convert abstract text TextFilterPlugin descendants to modules
- Stop requiring text filters to have special names
