### PR TITLE
Restore textfilter inheritence API

### DIFF
--- a/lib/publify_core/text_filter/markdown.rb
+++ b/lib/publify_core/text_filter/markdown.rb
@@ -4,9 +4,7 @@ require "text_filter_plugin"
 require "commonmarker"
 
 module PublifyCore::TextFilter
-  class Markdown < TextFilterPlugin
-    include TextFilterPlugin::Markup
-
+  class Markdown < TextFilterPlugin::Markup
     plugin_display_name "Markdown"
     plugin_description "Markdown markup language from" \
                        ' <a href="http://daringfireball.com/">Daring Fireball</a>'

--- a/lib/publify_core/text_filter/none.rb
+++ b/lib/publify_core/text_filter/none.rb
@@ -3,9 +3,7 @@
 require "text_filter_plugin"
 
 module PublifyCore::TextFilter
-  class None < TextFilterPlugin
-    include TextFilterPlugin::Markup
-
+  class None < TextFilterPlugin::Markup
     plugin_display_name "None"
     plugin_description "Raw HTML only"
 

--- a/lib/publify_core/text_filter/smartypants.rb
+++ b/lib/publify_core/text_filter/smartypants.rb
@@ -3,9 +3,7 @@
 require "rubypants"
 
 module PublifyCore::TextFilter
-  class Smartypants < TextFilterPlugin
-    include TextFilterPlugin::PostProcess
-
+  class Smartypants < TextFilterPlugin::PostProcess
     plugin_display_name "Smartypants"
     plugin_description "Converts HTML to use typographically correct quotes and dashes"
 

--- a/lib/publify_core/text_filter/twitterfilter.rb
+++ b/lib/publify_core/text_filter/twitterfilter.rb
@@ -5,9 +5,7 @@ require "html/pipeline"
 require "html/pipeline/hashtag/hashtag_filter"
 
 module PublifyCore::TextFilter
-  class Twitterfilter < TextFilterPlugin
-    include TextFilterPlugin::PostProcess
-
+  class Twitterfilter < TextFilterPlugin::PostProcess
     plugin_display_name "HTML Filter"
     plugin_description "Strip HTML tags"
 

--- a/lib/text_filter_plugin.rb
+++ b/lib/text_filter_plugin.rb
@@ -114,9 +114,15 @@ class TextFilterPlugin
   def self.logger
     @logger ||= ::Rails.logger || Logger.new($stdout)
   end
+
+  def self.abstract_filter!
+    @@filter_map.delete short_name
+  end
 end
 
-module TextFilterPlugin::PostProcess
+class TextFilterPlugin::PostProcess < TextFilterPlugin
+  abstract_filter!
+
   def self.filter_type
     "postprocess"
   end
@@ -155,40 +161,28 @@ module TextFilterPlugin::MacroMethods
   end
 end
 
-module TextFilterPlugin::MacroPre
-  def self.included(base)
-    base.extend ClassMethods
-    base.extend TextFilterPlugin::MacroMethods
-  end
+class TextFilterPlugin::MacroPre < TextFilterPlugin
+  abstract_filter!
+  extend TextFilterPlugin::MacroMethods
 
-  module ClassMethods
-    def filter_type
-      "macropre"
-    end
+  def self.filter_type
+    "macropre"
   end
 end
 
-module TextFilterPlugin::MacroPost
-  def self.included(base)
-    base.extend ClassMethods
-    base.extend TextFilterPlugin::MacroMethods
-  end
+class TextFilterPlugin::MacroPost < TextFilterPlugin
+  abstract_filter!
+  extend TextFilterPlugin::MacroMethods
 
-  module ClassMethods
-    def filter_type
-      "macropost"
-    end
+  def self.filter_type
+    "macropost"
   end
 end
 
-module TextFilterPlugin::Markup
-  def self.included(base)
-    base.extend ClassMethods
-  end
+class TextFilterPlugin::Markup < TextFilterPlugin
+  abstract_filter!
 
-  module ClassMethods
-    def filter_type
-      "markup"
-    end
+  def self.filter_type
+    "markup"
   end
 end

--- a/spec/lib/text_filter_plugin_spec.rb
+++ b/spec/lib/text_filter_plugin_spec.rb
@@ -20,51 +20,39 @@ RSpec.describe TextFilterPlugin do
     end
   end
 
-  shared_examples "a macro module" do
+  shared_examples "a macro class" do
     describe ".attributes_parse" do
       it 'parses lang="ruby" to {"lang" => "ruby"}' do
-        expect(derived_class.attributes_parse('<publify:code lang="ruby">'))
+        expect(described_class.attributes_parse('<publify:code lang="ruby">'))
           .to eq("lang" => "ruby")
       end
 
       it "parses lang='ruby' to {'lang' => 'ruby'}" do
-        expect(derived_class.attributes_parse("<publify:code lang='ruby'>"))
+        expect(described_class.attributes_parse("<publify:code lang='ruby'>"))
           .to eq("lang" => "ruby")
       end
     end
   end
 
-  describe described_class::MacroPre, "when included" do
-    let(:derived_class) do
-      Class.new.tap { |klass| klass.include described_class }
-    end
+  describe described_class::MacroPre do
+    it_behaves_like "a macro class"
 
-    it_behaves_like "a macro module"
-
-    it "declares including classes to be macropre filters" do
-      expect(derived_class.filter_type).to eq "macropre"
+    it "declares itself to be a macropre filter" do
+      expect(described_class.filter_type).to eq "macropre"
     end
   end
 
-  describe described_class::MacroPost, "when included" do
-    let(:derived_class) do
-      Class.new.tap { |klass| klass.include described_class }
-    end
+  describe described_class::MacroPost do
+    it_behaves_like "a macro class"
 
-    it_behaves_like "a macro module"
-
-    it "declares including classes to be macropost filters" do
-      expect(derived_class.filter_type).to eq "macropost"
+    it "declares itself to be a macropost filter" do
+      expect(described_class.filter_type).to eq "macropost"
     end
   end
 
-  describe described_class::Markup, "when included" do
-    let(:derived_class) do
-      Class.new.tap { |klass| klass.include described_class }
-    end
-
-    it "declares including classes to be markup filters" do
-      expect(derived_class.filter_type).to eq "markup"
+  describe described_class::Markup do
+    it "declares itself to be a markup filter" do
+      expect(described_class.filter_type).to eq "markup"
     end
   end
 end


### PR DESCRIPTION
For now, it is important to keep the API expected by the released Publify version 10.0.0.
