### PR TITLE
Provide proper validation feedback during setup

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,8 +2,8 @@
 
 class ArticlesController < ContentController
   before_action :login_required, only: [:preview, :preview_page]
-  before_action :auto_discovery_feed, only: [:show, :index]
   before_action :verify_config
+  before_action :auto_discovery_feed, only: [:show, :index]
 
   layout :theme_layout, except: [:trackback]
 

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -9,14 +9,12 @@ class SetupController < BaseController
   end
 
   def create
-    this_blog.blog_name = params[:setting][:blog_name]
+    this_blog.blog_name = blog_params[:blog_name]
     this_blog.base_url = blog_base_url
 
-    @user = User.new(login: "admin",
-                     email: params[:setting][:email],
-                     password: params[:setting][:password],
-                     text_filter_name: this_blog.text_filter,
-                     nickname: "Publify Admin")
+    @user = User.new(user_params.merge(login: "admin",
+                                       text_filter_name: this_blog.text_filter,
+                                       nickname: "Publify Admin"))
     @user.name = @user.login
 
     return render :index unless this_blog.valid? && @user.valid?
@@ -37,6 +35,14 @@ class SetupController < BaseController
   end
 
   private
+
+  def blog_params
+    params.require(:blog).permit(:blog_name)
+  end
+
+  def user_params
+    params.require(:user).permit(:email, :password)
+  end
 
   def create_first_post(user)
     this_blog.articles.build(title: I18n.t("setup.article.title"),

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -5,6 +5,7 @@ class SetupController < BaseController
   layout "accounts"
 
   def index
+    this_blog.blog_name = ""
     @user = User.new
   end
 

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -4,7 +4,9 @@ class SetupController < BaseController
   before_action :check_config
   layout "accounts"
 
-  def index; end
+  def index
+    @user = User.new
+  end
 
   def create
     this_blog.blog_name = params[:setting][:blog_name]
@@ -17,7 +19,7 @@ class SetupController < BaseController
                      nickname: "Publify Admin")
     @user.name = @user.login
 
-    return redirect_to setup_url unless this_blog.valid? && @user.valid?
+    return render :index unless this_blog.valid? && @user.valid?
 
     this_blog.save!
     @user.save!

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -17,10 +17,10 @@ class SetupController < BaseController
                      nickname: "Publify Admin")
     @user.name = @user.login
 
-    unless this_blog.save && @user.save
-      redirect_to setup_url
-      return
-    end
+    return redirect_to setup_url unless this_blog.valid? && @user.valid?
+
+    this_blog.save!
+    @user.save!
 
     sign_in @user
 

--- a/app/views/setup/index.html.erb
+++ b/app/views/setup/index.html.erb
@@ -18,16 +18,20 @@
   <div class='alert alert-info'>
     <small><%= t('.welcome_to_your_blog_setup', publify: link_to('Publify', 'https://publify.github.io/')) %></small>
   </div>
-  <div class='form-group'>
-    <%= text_field(:setting, :blog_name, class: 'form-control', placeholder: t('.blog_name')) %>
-  </div>
-  <div class='form-group'>
-    <%= text_field(:setting, :email, class: 'form-control', placeholder: t('.your_mail')) %>
-  </div>
-  <div class='form-group'>
-    <%= label_tag :setting_password, t('.password') %><br />
-    <%= password_field(:setting, :password, class: 'form-control') %>
-  </div>
+  <%= fields model: this_blog do |form| %>
+    <div class='form-group'>
+      <%= form.text_field(:blog_name, class: 'form-control', placeholder: t('.blog_name')) %>
+    </div>
+  <% end %>
+  <%= fields model: @user do |form| %>
+    <div class='form-group'>
+      <%= form.text_field(:email, class: 'form-control', placeholder: t('.your_mail')) %>
+    </div>
+    <div class='form-group'>
+      <%= form.label :password, t('.password') %><br>
+      <%= form.password_field(:password, class: 'form-control') %>
+    </div>
+  <% end %>
 
-  <input type="submit" id="submit" class='btn btn-lg btn-success btn-block' value="<%= t('generic.save') %>" />
+  <input type="submit" id="submit" class='btn btn-lg btn-success btn-block' value="<%= t('generic.save') %>">
 <% end %>

--- a/app/views/setup/index.html.erb
+++ b/app/views/setup/index.html.erb
@@ -1,3 +1,19 @@
+<div class="row">
+  <div class="col-md-8 col-md-offset-2" id="error-message-page">
+    <% if @user.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= t("errors.template.header", model: 'blog', count: @user.errors.count) %></h2>
+        <p><%= t("errors.template.body") %></p>
+        <ul>
+          <% @user.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+</div>
+
 <%= form_tag action: 'index' do %>
   <div class='alert alert-info'>
     <small><%= t('.welcome_to_your_blog_setup', publify: link_to('Publify', 'https://publify.github.io/')) %></small>

--- a/app/views/setup/index.html.erb
+++ b/app/views/setup/index.html.erb
@@ -1,5 +1,16 @@
 <div class="row">
   <div class="col-md-8 col-md-offset-2" id="error-message-page">
+    <% if this_blog.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= t("errors.template.header", model: 'blog', count: this_blog.errors.count) %></h2>
+        <p><%= t("errors.template.body") %></p>
+        <ul>
+          <% this_blog.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
     <% if @user.errors.any? %>
       <div id="error_explanation">
         <h2><%= t("errors.template.header", model: 'blog', count: @user.errors.count) %></h2>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,9 +13,9 @@
 blog = Blog.first || Blog.create!
 
 unless blog.sidebars.any?
-  PageSidebar.create!(active_position: 0, staged_position: 0, blog_id: blog.id)
-  TagSidebar.create!(active_position: 1, blog_id: blog.id)
-  ArchivesSidebar.create!(active_position: 2, blog_id: blog.id)
-  StaticSidebar.create!(active_position: 3, blog_id: blog.id)
-  MetaSidebar.create!(active_position: 4, blog_id: blog.id)
+  PageSidebar.create!(active_position: 0, staged_position: 0, blog: blog)
+  TagSidebar.create!(active_position: 1, blog: blog)
+  ArchivesSidebar.create!(active_position: 2, blog: blog)
+  StaticSidebar.create!(active_position: 3, blog: blog)
+  MetaSidebar.create!(active_position: 4, blog: blog)
 end

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe SetupController, type: :controller do
       context "when passing correct parameters" do
         before do
           ActionMailer::Base.deliveries.clear
-          post :create, params: { setting: { blog_name: "Foo", email: "foo@bar.net",
-                                             password: strong_password } }
+          post :create, params: { blog: { blog_name: "Foo" },
+                                  user: { email: "foo@bar.net",
+                                          password: strong_password } }
         end
 
         it "correctly initializes blog and users" do
@@ -66,8 +67,9 @@ RSpec.describe SetupController, type: :controller do
 
       context "when passing incorrect parameters" do
         it "does no setup when blog name is empty" do
-          post :create, params: { setting: { blog_name: "", email: "foo@bar.net",
-                                             password: strong_password } }
+          post :create, params: { blog: { blog_name: "" },
+                                  user: { email: "foo@bar.net",
+                                          password: strong_password } }
           aggregate_failures do
             expect(response).to render_template "index"
             expect(blog.reload).not_to be_configured
@@ -75,8 +77,9 @@ RSpec.describe SetupController, type: :controller do
         end
 
         it "does no setup when email is empty" do
-          post :create, params: { setting: { blog_name: "Foo", email: "",
-                                             password: strong_password } }
+          post :create, params: { blog: { blog_name: "Foo" },
+                                  user: { email: "",
+                                          password: strong_password } }
           aggregate_failures do
             expect(response).to render_template "index"
             expect(blog.reload).not_to be_configured
@@ -84,8 +87,9 @@ RSpec.describe SetupController, type: :controller do
         end
 
         it "does no setup when password is empty" do
-          post :create, params: { setting: { blog_name: "Foo", email: "foo@bar.net",
-                                             password: "" } }
+          post :create, params: { blog: { blog_name: "Foo" },
+                                  user: { email: "foo@bar.net",
+                                          password: "" } }
           aggregate_failures do
             expect(response).to render_template "index"
             expect(blog.reload).not_to be_configured
@@ -93,8 +97,9 @@ RSpec.describe SetupController, type: :controller do
         end
 
         it "does no setup when password is weak" do
-          post :create, params: { setting: { blog_name: "Foo", email: "foo@bar.net",
-                                             password: "foo123bar" } }
+          post :create, params: { blog: { blog_name: "Foo" },
+                                  user: { email: "foo@bar.net",
+                                          password: "foo123bar" } }
           aggregate_failures do
             expect(response).to render_template "index"
             expect(blog.reload).not_to be_configured
@@ -106,7 +111,8 @@ RSpec.describe SetupController, type: :controller do
     describe "when a blog is configured and has some users" do
       before do
         create(:blog)
-        post :create, params: { setting: { blog_name: "Foo", email: "foo@bar.net" } }
+        post :create, params: { blog: { blog_name: "Foo" },
+                                user: { email: "foo@bar.net" } }
       end
 
       specify { expect(response).to redirect_to(controller: "articles", action: "index") }

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe SetupController, type: :controller do
 
   describe "#index" do
     describe "when blog is not configured" do
+      render_views
+
       before do
         # Set up database similar to result of db:setup
         Blog.create
@@ -14,6 +16,10 @@ RSpec.describe SetupController, type: :controller do
       end
 
       specify { expect(response).to render_template("index") }
+
+      it "does not show the default blog name in the form" do
+        expect(response.body).to have_css "input#blog_blog_name[value='']"
+      end
     end
 
     describe "when a blog is configured and has some users" do

--- a/spec/controllers/setup_controller_spec.rb
+++ b/spec/controllers/setup_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SetupController, type: :controller do
           post :create, params: { setting: { blog_name: "", email: "foo@bar.net",
                                              password: strong_password } }
           aggregate_failures do
-            expect(response).to redirect_to(action: "index")
+            expect(response).to render_template "index"
             expect(blog.reload).not_to be_configured
           end
         end
@@ -78,7 +78,7 @@ RSpec.describe SetupController, type: :controller do
           post :create, params: { setting: { blog_name: "Foo", email: "",
                                              password: strong_password } }
           aggregate_failures do
-            expect(response).to redirect_to(action: "index")
+            expect(response).to render_template "index"
             expect(blog.reload).not_to be_configured
           end
         end
@@ -87,7 +87,7 @@ RSpec.describe SetupController, type: :controller do
           post :create, params: { setting: { blog_name: "Foo", email: "foo@bar.net",
                                              password: "" } }
           aggregate_failures do
-            expect(response).to redirect_to(action: "index")
+            expect(response).to render_template "index"
             expect(blog.reload).not_to be_configured
           end
         end
@@ -96,7 +96,7 @@ RSpec.describe SetupController, type: :controller do
           post :create, params: { setting: { blog_name: "Foo", email: "foo@bar.net",
                                              password: "foo123bar" } }
           aggregate_failures do
-            expect(response).to redirect_to(action: "index")
+            expect(response).to render_template "index"
             expect(blog.reload).not_to be_configured
           end
         end

--- a/spec/features/setup_spec.rb
+++ b/spec/features/setup_spec.rb
@@ -18,9 +18,9 @@ RSpec.feature "Blog setup", type: :feature do
     expect(page).to have_text I18n.t!("setup.index.welcome_to_your_blog_setup")
 
     # Set up the blog
-    fill_in :setting_blog_name, with: "Awesome blog"
-    fill_in :setting_email, with: "foo@bar.com"
-    fill_in :setting_password, with: strong_password
+    fill_in :blog_blog_name, with: "Awesome blog"
+    fill_in :user_email, with: "foo@bar.com"
+    fill_in :user_password, with: strong_password
     click_button I18n.t!("generic.save")
 
     # Confirm set up success
@@ -49,14 +49,19 @@ RSpec.feature "Blog setup", type: :feature do
     expect(User.first.email).to eq "foo@bar.com"
   end
 
-  scenario "setup fails due to password weakness" do
+  scenario "setup fails at first due to password weakness" do
     visit "/setup"
-    fill_in :setting_blog_name, with: "Awesome blog"
-    fill_in :setting_email, with: "foo@bar.com"
-    fill_in :setting_password, with: "not-strong"
+    fill_in :blog_blog_name, with: "Awesome blog"
+    fill_in :user_email, with: "foo@bar.com"
+    fill_in :user_password, with: "not-strong"
     click_button I18n.t!("generic.save")
 
     expect(page)
       .to have_text "Password not strong enough. It scored 2. It must score at least 4."
+
+    fill_in :user_password, with: strong_password
+    click_button I18n.t!("generic.save")
+
+    expect(page).to have_text I18n.t!("accounts.confirm.success")
   end
 end

--- a/spec/features/setup_spec.rb
+++ b/spec/features/setup_spec.rb
@@ -48,4 +48,15 @@ RSpec.feature "Blog setup", type: :feature do
     # Confirm proper setting fo user properties
     expect(User.first.email).to eq "foo@bar.com"
   end
+
+  scenario "setup fails due to password weakness" do
+    visit "/setup"
+    fill_in :setting_blog_name, with: "Awesome blog"
+    fill_in :setting_email, with: "foo@bar.com"
+    fill_in :setting_password, with: "not-strong"
+    click_button I18n.t!("generic.save")
+
+    expect(page)
+      .to have_text "Password not strong enough. It scored 2. It must score at least 4."
+  end
 end

--- a/spec/features/setup_spec.rb
+++ b/spec/features/setup_spec.rb
@@ -64,4 +64,11 @@ RSpec.feature "Blog setup", type: :feature do
 
     expect(page).to have_text I18n.t!("accounts.confirm.success")
   end
+
+  scenario "setup fails due to missing blog name" do
+    visit "/setup"
+    click_button I18n.t!("generic.save")
+
+    expect(page).to have_text "Blog name can't be blank"
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/publify/publify/issues/1142.

- Ensure blog is not set up if parameters are invalid
- Provide feedback about weak password during setup
- Keep entered values when there is a validation error during setup
- Don't needlessly set autodiscovery feeds if blog is not configured
- Avoid each sidebar loading the blog during seeding
- Clear blog name in first setup form
- Provide feedback for missing blog name during setup
