### PR TITLE
Stop using and depending on REXML

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class Admin::DashboardController < Admin::BaseController
-  require "open-uri"
-  require "time"
-  require "rexml/document"
-
   def index
     today = Time.zone.now.strftime("%Y-%m-%d 00:00")
 

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "open-uri"
-require "time"
-require "rexml/document"
-
 class Admin::ThemesController < Admin::BaseController
   def index
     @themes = Theme.find_all

--- a/lib/publify_core/testing_support/feed_assertions.rb
+++ b/lib/publify_core/testing_support/feed_assertions.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "feedjira"
-require "rexml/document"
 
 module PublifyCore
   module TestingSupport
@@ -9,9 +8,7 @@ module PublifyCore
       # TODO: Clean up use of these Test::Unit style expectations
       def assert_xml(xml)
         expect(xml).not_to be_empty
-        expect do
-          assert REXML::Document.new(xml)
-        end.not_to raise_error
+        expect { Nokogiri::XML.parse(xml) }.not_to raise_error
       end
 
       def assert_atom10(feed, count)


### PR DESCRIPTION
Nokogiri is available via Rails and REXML is no longer a default Ruby gem.

- Use Nokogiri::XML to test XML
- Remove needless requires
