### PR TITLE
Remove inline styles assigned in ERB templates

### DIFF
--- a/app/assets/javascripts/optional_field_toggle.js
+++ b/app/assets/javascripts/optional_field_toggle.js
@@ -1,4 +1,5 @@
 $(document).ready(function() {
+  $('.optional_field').hide();
   $('.optional-field-toggle').on("click", function(e){
     $('.optional_field').fadeToggle();
     e.preventDefault();

--- a/app/assets/javascripts/spinnable.js
+++ b/app/assets/javascripts/spinnable.js
@@ -1,5 +1,10 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
-  $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:complete', function(evt, xhr, status){ $('#spinner').hide();})
+  $('#spinner').hide().removeClass("hidden");
+  $('form.spinnable').on('ajax:before', function(evt, xhr, status){
+    $('#spinner').show();
+  });
+  $('form.spinnable').on('ajax:complete', function(evt, xhr, status){
+    $('#spinner').hide();
+  });
 });

--- a/app/assets/stylesheets/administration_structure.css.scss
+++ b/app/assets/stylesheets/administration_structure.css.scss
@@ -1,7 +1,7 @@
 /* General */
 
 body {
-  padding-top: 40px;
+  padding-top: 60px;
 }
 
 footer {

--- a/app/assets/stylesheets/publify.css.scss
+++ b/app/assets/stylesheets/publify.css.scss
@@ -28,3 +28,7 @@
 .admin-tools-reveal:hover .admintools {
   display: block;
 }
+
+.tag-sidebar-tag-cloud {
+  overflow: hidden;
+}

--- a/app/assets/stylesheets/publify.css.scss
+++ b/app/assets/stylesheets/publify.css.scss
@@ -32,3 +32,7 @@
 .tag-sidebar-tag-cloud {
   overflow: hidden;
 }
+
+.hidden {
+  display: none;
+}

--- a/app/assets/stylesheets/publify.css.scss
+++ b/app/assets/stylesheets/publify.css.scss
@@ -33,6 +33,20 @@
   overflow: hidden;
 }
 
+.tag-sidebar-tag-67 { font-size: 0.67em; }
+.tag-sidebar-tag-75 { font-size: 0.75em; }
+.tag-sidebar-tag-83 { font-size: 0.83em; }
+.tag-sidebar-tag-91 { font-size: 0.91em; }
+.tag-sidebar-tag-100 { font-size: 1em; }
+.tag-sidebar-tag-112 { font-size: 1.12em; }
+.tag-sidebar-tag-125 { font-size: 1.25em; }
+.tag-sidebar-tag-137 { font-size: 1.37em; }
+.tag-sidebar-tag-150 { font-size: 1.50em; }
+.tag-sidebar-tag-162 { font-size: 1.62em; }
+.tag-sidebar-tag-175 { font-size: 1.75em; }
+.tag-sidebar-tag-187 { font-size: 1.87em; }
+.tag-sidebar-tag-200 { font-size: 2em; }
+
 .hidden {
   display: none;
 }

--- a/app/models/tag_sidebar.rb
+++ b/app/models/tag_sidebar.rb
@@ -18,12 +18,34 @@ class TagSidebar < Sidebar
     average = total.to_f / @tags.size
     @sizes = tags.reduce({}) do |h, tag|
       size = tag.content_counter.to_f / average
-      h.merge tag => size.clamp(2.0 / 3.0, 2) * 100
+      h.merge tag => bucket(size)
     end
   end
 
-  def font_multiplier
-    80
+  BUCKETS = [
+    67,
+    75,
+    83,
+    91,
+    100,
+    112,
+    125,
+    137,
+    150,
+    162,
+    175,
+    187,
+    200
+  ].freeze
+
+  private
+
+  def bucket(size)
+    base_size = size.clamp(2.0 / 3.0, 2) * 100
+    BUCKETS.each do |sz|
+      return sz if sz >= base_size
+    end
+    BUCKETS.last
   end
 end
 

--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -33,7 +33,7 @@
         </div>
         <div class="form-group">
           <%= submit_tag(t('.search'), class: 'btn btn-success') %>
-          <span id="spinner" style="display:none;"><%= image_tag('spinner.gif') %></span>
+          <span id="spinner" class="hidden"><%= image_tag('spinner.gif') %></span>
         </div>
       </div>
       <br style="clear: both">

--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -20,7 +20,7 @@
   </p>
 
   <div class="panel panel-default">
-    <div class="panel-heading">
+    <div class="panel-heading clearfix">
       <div class="pull-right">
         <div class="form-group">
           <%= select_tag('search[user_id]', options_from_collection_for_select(User.all, 'id', 'name'), prompt: t('.select_an_author'), class: 'form-control') %>
@@ -36,7 +36,6 @@
           <span id="spinner" class="hidden"><%= image_tag('spinner.gif') %></span>
         </div>
       </div>
-      <br style="clear: both">
     </div>
   </div>
   <table class="table table-hover">

--- a/app/views/articles/_comment_form.html.erb
+++ b/app/views/articles/_comment_form.html.erb
@@ -16,11 +16,11 @@
           </small>
         </td>
       </tr>
-      <tr class="optional_field" style="display: none">
+      <tr class="optional_field">
         <td><p><label for="comment_url"><%= t('.your_blog') %></label></p></td>
         <td> <%= text_field 'comment', 'url' %></td>
       </tr>
-      <tr class="optional_field" style="display: none">
+      <tr class="optional_field">
         <td><p><label for="comment_email"><%= t('.your_email') %></label></p></td>
         <td> <%= text_field 'comment', 'email' %></td>
       </tr>

--- a/app/views/articles/_comment_form.html.erb
+++ b/app/views/articles/_comment_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag @article.comment_url, id: 'comment_form', remote: true do %>
   <div class="comment-box">
-    <div id="errors" style="display: none"></div>
-    <div id="preview" style="display: none"></div>
+    <div id="errors" class="hidden"></div>
+    <div id="preview" class="hidden"></div>
 
     <a name="respond"></a>
     <table cellpadding="4" cellspacing="0" class="frm-tbl">

--- a/app/views/articles/comment_failed.js.erb
+++ b/app/views/articles/comment_failed.js.erb
@@ -1,3 +1,3 @@
 var message = "<%= j render 'articles/comment_errors', comment: @comment %>";
 $('#preview').hide();
-$('#errors').hide().html(message).fadeIn();
+$('#errors').hide().removeClass("hidden").html(message).fadeIn();

--- a/app/views/comments/preview.js.erb
+++ b/app/views/comments/preview.js.erb
@@ -1,3 +1,3 @@
 var preview = "<%= j render 'articles/comment_preview', comment: @comment %>";
 $('#errors').hide();
-$('#preview').hide().html(preview).fadeIn();
+$('#preview').hide().removeClass("hidden").html(preview).fadeIn();

--- a/app/views/layouts/administration.html.erb
+++ b/app/views/layouts/administration.html.erb
@@ -12,9 +12,7 @@
   <body>
     <%= render 'admin/shared/menu' %>
     <div class='container-fluid'>
-      <div style='margin-top:20px'>
-        <%= render 'shared/flash', flash: flash %>
-      </div>
+      <%= render 'shared/flash', flash: flash %>
       <% if content_for?(:page_heading) %>
         <div class='page-header'>
           <%= yield :page_heading %>

--- a/app/views/search_sidebar/_content.html.erb
+++ b/app/views/search_sidebar/_content.html.erb
@@ -7,4 +7,3 @@
     <input type="submit" value="<%= t('.search') %>">
   <% end %>
 </div>
-<br style="clear: right">

--- a/app/views/tag_sidebar/_content.html.erb
+++ b/app/views/tag_sidebar/_content.html.erb
@@ -3,7 +3,7 @@
   <div class="sidebar-body">
     <p class="tag-sidebar-tag-cloud">
     <% sidebar.tags.each do |tag| %>
-      <span style="font-size:<%= sidebar.sizes[tag] %>%"><%= link_to tag.display_name, tag_url(tag.name) %></span>
+      <span class="tag-sidebar-tag-<%= sidebar.sizes[tag] %>"><%= link_to tag.display_name, tag_url(tag.name) %></span>
     <% end %>
     </p>
   </div>

--- a/app/views/tag_sidebar/_content.html.erb
+++ b/app/views/tag_sidebar/_content.html.erb
@@ -1,7 +1,7 @@
 <% unless sidebar.tags.blank? %>
   <h3 class="sidebar-title"><%= t('.tags') %></h3>
   <div class="sidebar-body">
-    <p style="overflow:hidden">
+    <p class="tag-sidebar-tag-cloud">
     <% sidebar.tags.each do |tag| %>
       <span style="font-size:<%= sidebar.sizes[tag] %>%"><%= link_to tag.display_name, tag_url(tag.name) %></span>
     <% end %>

--- a/spec/models/tag_sidebar_spec.rb
+++ b/spec/models/tag_sidebar_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe TagSidebar, type: :model do
       create(:article, keywords: "foo, quuz")
 
       result = sidebar.sizes
-      expect(result.values.uniq).to contain_exactly (2.0 / 3.0 * 100), 200
+      expect(result.values.uniq).to contain_exactly 67, 200
     end
   end
 end


### PR DESCRIPTION
Part of #126.

- Hide spinner initially with a class
- Remove superfluous break
- Hide optional comment form fields with JavaScript
- Apply tag cloud styling using a class
- Ensure panel heading height using a class
- Fix admin flash position without inline styling
- Initially hide comment feedback elements using a class
- Group tags into buckets with statically assigned sizes
