### PR TITLE
Support Ruby 3.0 and up

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - 'spec/dummy/bin/*'
     - 'spec/dummy/db/schema.rb'
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Rails:
   Enabled: true

--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -37,8 +37,8 @@ module BaseHelper
     javascript_include_tag "/javascripts/theme/#{name}.js" if File.exist? src
   end
 
-  def render_to_string(*args, &block)
-    controller.send(:render_to_string, *args, &block)
+  def render_to_string(...)
+    controller.send(:render_to_string, ...)
   end
 
   def link_to_permalink(item, title,

--- a/lib/format.rb
+++ b/lib/format.rb
@@ -2,8 +2,8 @@
 
 module Format
   # Laxly matches an IP Address , would also pass numbers > 255 though
-  IP_ADDRESS = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.freeze
+  IP_ADDRESS = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
 
   # Laxly matches an HTTP(S) URI
-  HTTP_URI = %r{^https?://\S+$}.freeze
+  HTTP_URI = %r{^https?://\S+$}
 end

--- a/lib/publify_core/string_ext.rb
+++ b/lib/publify_core/string_ext.rb
@@ -36,13 +36,12 @@ module PublifyCore
     end
 
     # Strips any html markup from a string
-    TYPO_TAG_KEY = TYPO_ATTRIBUTE_KEY = /[\w:_-]+/.freeze
-    TYPO_ATTRIBUTE_VALUE = /(?:[A-Za-z0-9]+|(?:'[^']*?'|"[^"]*?"))/.freeze
-    TYPO_ATTRIBUTE = /(?:#{TYPO_ATTRIBUTE_KEY}(?:\s*=\s*#{TYPO_ATTRIBUTE_VALUE})?)/.freeze
-    TYPO_ATTRIBUTES = /(?:#{TYPO_ATTRIBUTE}(?:\s+#{TYPO_ATTRIBUTE})*)/.freeze
-    TAG =
-      %r{<[!/?\[]?(?:#{TYPO_TAG_KEY}|--)(?:\s+#{TYPO_ATTRIBUTES})?\s*(?:[!/?\]]+|--)?>}
-        .freeze
+    TYPO_TAG_KEY = TYPO_ATTRIBUTE_KEY = /[\w:_-]+/
+    TYPO_ATTRIBUTE_VALUE = /(?:[A-Za-z0-9]+|(?:'[^']*?'|"[^"]*?"))/
+    TYPO_ATTRIBUTE = /(?:#{TYPO_ATTRIBUTE_KEY}(?:\s*=\s*#{TYPO_ATTRIBUTE_VALUE})?)/
+    TYPO_ATTRIBUTES = /(?:#{TYPO_ATTRIBUTE}(?:\s+#{TYPO_ATTRIBUTE})*)/
+    TAG = %r{<[!/?\[]?(?:#{TYPO_TAG_KEY}|--)(?:\s+#{TYPO_ATTRIBUTES})?\s*(?:[!/?\]]+|--)?>}
+
     def strip_html
       gsub(TAG, "").gsub(/\s+/, " ").strip
     end

--- a/publify_core.gemspec
+++ b/publify_core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.files       = File.open("Manifest.txt").readlines.map(&:chomp)
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.add_dependency "aasm", "~> 5.0"
   s.add_dependency "akismet", "~> 3.0"


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
- Autocorrect Style/RedundantFreeze
- Autocorrect Style/ArgumentsForwarding
