### PR TITLE
Safely link target URLs for Redirects in admin

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -17,8 +17,8 @@ class Redirect < ApplicationRecord
     return path if %r{^(https?)://([^/]*)(.*)}.match?(path)
 
     url_root = blog.root_path
-    unless url_root.nil? || path[0, url_root.length] == url_root
-      path = File.join(url_root, path)
+    if url_root.length == 0 || path[0, url_root.length] != url_root
+      path = blog.url_for(path, only_path: true)
     end
     path
   end

--- a/app/views/admin/redirects/_index_and_form.html.erb
+++ b/app/views/admin/redirects/_index_and_form.html.erb
@@ -58,7 +58,7 @@
             <%= button_to_delete redirect %>
           </div>
         </td>
-        <td><%= link_to(redirect.to_path, redirect.to_path) %></td>
+        <td><%= link_to(redirect.to_path, redirect.full_to_path) %></td>
       </tr>
       <% end %>
       <%= display_pagination(@redirects, 2) %>

--- a/spec/controllers/admin/redirects_controller_spec.rb
+++ b/spec/controllers/admin/redirects_controller_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Admin::RedirectsController, type: :controller do
+  let!(:blog) { create(:blog) }
+
   before do
-    create(:blog)
     admin = create(:user, :as_admin)
     sign_in admin
   end
@@ -38,6 +39,16 @@ RSpec.describe Admin::RedirectsController, type: :controller do
       it "renders properly with redirects present" do
         create(:redirect)
         expect { get :index }.not_to raise_error
+      end
+
+      it "links to the redirect target using the full target path" do
+        blog.update(base_url: "https://foo.bar/baz")
+        create(:redirect, to_path: "qux")
+        get :index
+        aggregate_failures do
+          expect(response.body).not_to have_link href: "qux"
+          expect(response.body).to have_link "qux", href: "/baz/qux"
+        end
       end
     end
   end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -3,21 +3,37 @@
 require "rails_helper"
 
 RSpec.describe Redirect, type: :model do
-  let(:blog) { create(:blog) }
-
-  it "redirects are unique" do
-    expect { blog.redirects.create!(from_path: "foo/bar", to_path: "/") }.not_to raise_error
-
-    redirect = blog.redirects.build(from_path: "foo/bar", to_path: "/")
-
-    expect(redirect).not_to be_valid
-    expect(redirect.errors[:from_path]).to eq(["has already been taken"])
-  end
-
   describe "#from_url" do
     it "is based on the blog's base_url" do
+      blog = Blog.new(base_url: "https://quuz.bar/foo")
       redirect = blog.redirects.build(from_path: "right/here", to_path: "over_there")
       expect(redirect.from_url).to eq "#{blog.base_url}/right/here"
+    end
+  end
+
+  describe "#full_to_path" do
+    it "returns to_path if it includes an http or https scheme" do
+      blog = Blog.new(base_url: "https://quuz.bar/")
+      redirect = described_class.new(to_path: "https://foo.baz/", blog: blog)
+      expect(redirect.full_to_path).to eq "https://foo.baz/"
+    end
+
+    it "includes the blog's root path" do
+      blog = Blog.new(base_url: "https://quuz.bar/foo")
+      redirect = described_class.new(to_path: "baz", blog: blog)
+      expect(redirect.full_to_path).to eq "/foo/baz"
+    end
+
+    it "makes malicious target paths safe" do
+      blog = Blog.new(base_url: "https://quuz.bar/")
+      redirect = described_class.new(to_path: "javascript:alert()", blog: blog)
+      expect(redirect.full_to_path).to eq "/javascript:alert()"
+    end
+
+    it "ignores the blog's root path if it is included in the redirect" do
+      blog = Blog.new(base_url: "https://quuz.bar/foo")
+      redirect = described_class.new(to_path: "/foo/baz", blog: blog)
+      expect(redirect.full_to_path).to eq "/foo/baz"
     end
   end
 
@@ -30,6 +46,18 @@ RSpec.describe Redirect, type: :model do
 
     it "requires to_path to not be too long" do
       expect(redirect).to validate_length_of(:to_path).is_at_most(255)
+    end
+
+    it "requires redirects to be unique" do
+      blog = create(:blog)
+      blog.redirects.create!(from_path: "foo/bar", to_path: "/")
+
+      redirect = blog.redirects.build(from_path: "foo/bar", to_path: "/")
+
+      aggregate_failures do
+        expect(redirect).not_to be_valid
+        expect(redirect.errors[:from_path]).to eq(["has already been taken"])
+      end
     end
   end
 end


### PR DESCRIPTION
This prevents redirect targets like are e.g. javascript URLs from being interpreted as such in the admin: All redirect targets should be http(s) URLs. In the frontend, the conversion of the target path is already done.

- Force non-http(s) redirects to be interpreted as paths
- Safely link to redirect target in the admin
