### PR TITLE
Upgrade jquery-ui-rails to version 7.0

### DIFF
--- a/publify_core.gemspec
+++ b/publify_core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency "html-pipeline", "~> 2.14"
   s.add_dependency "html-pipeline-hashtag", "~> 0.1.2"
   s.add_dependency "jquery-rails", ">= 4.5", "< 4.7"
-  s.add_dependency "jquery-ui-rails", "~> 6.0.1"
+  s.add_dependency "jquery-ui-rails", "~> 7.0"
   s.add_dependency "kaminari", ["~> 1.2", ">= 1.2.1"]
   s.add_dependency "marcel", "~> 1.0.0"
   s.add_dependency "mini_magick", ["~> 4.9", ">= 4.9.4"]


### PR DESCRIPTION
This version of jquery-ui-rails upgrades jquery-ui to 1.13.0, resolving several vulnerabilities.
