### PR TITLE
Display Theme description nicely in the admin

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -3,16 +3,12 @@
 class Admin::ThemesController < Admin::BaseController
   def index
     @themes = Theme.find_all
-    @themes.each do |theme|
-      # TODO: Move to Theme
-      theme.description_html = TextFilter.none.filter_text(theme.description)
-    end
     @active = this_blog.current_theme
   end
 
   def preview
     theme = Theme.find(params[:theme])
-    send_file File.join(theme.path, "preview.png"),
+    send_file theme.theme_file("preview.png"),
               type: "image/png", disposition: "inline", stream: false
   end
 

--- a/lib/theme.rb
+++ b/lib/theme.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Theme
-  attr_accessor :name, :path, :description_html
+  attr_reader :name, :path
 
   def initialize(name, path)
     @name = name
@@ -16,16 +16,27 @@ class Theme
   end
 
   def description
-    about_file = "#{path}/about.markdown"
-    if File.exist? about_file
-      File.read about_file
-    else
-      "### #{name}"
-    end
+    @description ||=
+      begin
+        about_file = theme_file("about.markdown")
+        if File.exist? about_file
+          File.read about_file
+        else
+          "### #{name}"
+        end
+      end
+  end
+
+  def description_html
+    TextFilter.markdown.filter_text(description)
   end
 
   def view_path
     "#{path}/views"
+  end
+
+  def theme_file(filename)
+    File.join(path, filename)
   end
 
   # Find a theme, given the theme name

--- a/spec/lib/theme_spec.rb
+++ b/spec/lib/theme_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe Theme, type: :model do
     end
   end
 
+  describe "#description_html" do
+    it "returns the contents of the about file processed as markdown" do
+      expect(default_theme.description_html)
+        .to start_with "<h4>Plain theme for Publify</h4>"
+    end
+  end
+
   describe ".find_all" do
     let(:theme_directories) do
       Dir.glob(PublifyCore::Engine.instance.root.join("themes/[a-zA-Z0-9]*"))


### PR DESCRIPTION
The description must be processed as Markdown before displaying it.
