### PR TITLE
Update read.html.erb - both admin and publisher can edit articles

### DIFF
--- a/app/views/articles/read.html.erb
+++ b/app/views/articles/read.html.erb
@@ -1,5 +1,5 @@
 <div class="post admin-tools-reveal">
-  <% if current_user&.profile == "admin" %>
+  <% if current_user&.profile.in? [User::ADMIN, User::PUBLISHER] %>
     <%= link_to(t('.edit'), edit_admin_article_path(@article.id), class: 'admintools', id: 'admin_article') %>
   <% end %>
   <% cache @article do %>


### PR DESCRIPTION
Amend the user.profile check to allow both admin and publisher to see the admintools edit link.

(I don't really know how to write tests but would need to create an admin user, a publisher user, and an article, then visit its public link and confirm that the edit link is on the page.)