### PR TITLE
Fix linting job in GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -47,10 +47,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install newer libyaml for consistent normalization
-        run: |
-          wget http://mirrors.kernel.org/ubuntu/pool/main/liby/libyaml/libyaml-0-2_0.2.5-1_amd64.deb
-          sudo apt-get install ./libyaml-0-2_0.2.5-1_amd64.deb
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This removes the installation of a different libyaml version. This now makes the installation of Psych fail and is no longer needed.
