### PR TITLE
Use known set of allowed attributes when autosaving an Article

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -108,7 +108,7 @@ class Admin::ArticlesController < Admin::BaseController
 
     fetch_fresh_or_existing_draft_for_article
 
-    @article.attributes = params[:article].permit!
+    @article.assign_attributes(update_params)
 
     @article.author = current_user
     @article.save_attachments!(params[:attachments])


### PR DESCRIPTION
The attributes of an Article are known, so there is no need to permit all parameters. Since it is also unsafe, replace it with the already known set of good parameters defined in #update_params.