### PR TITLE
Permit only valid settings keys when updating blog settings

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -36,7 +36,7 @@ class Admin::SettingsController < Admin::BaseController
   VALID_ACTIONS = %w(index write feedback display).freeze
 
   def settings_params
-    @settings_params ||= params.require(:setting).permit!
+    @settings_params ||= params.require(:setting).permit(@setting.settings_keys)
   end
 
   def action_param

--- a/app/models/config_manager.rb
+++ b/app/models/config_manager.rb
@@ -28,6 +28,10 @@ module ConfigManager
       fields[key.to_s].default
     end
 
+    def settings_keys
+      fields.keys
+    end
+
     private
 
     def add_setting_reader(item)
@@ -63,6 +67,10 @@ module ConfigManager
 
   def canonicalize(key, value)
     self.class.fields[key.to_s].canonicalize(value)
+  end
+
+  def settings_keys
+    self.class.settings_keys
   end
 
   class Item


### PR DESCRIPTION
The settings controller is only for updating blog settings. Instead of permitting all parameters, which is unsafe, limit permitted parameters to those that are actually blog settings.