### PR TITLE
Limit allowed SEO settings params

### DIFF
--- a/app/controllers/admin/seo_controller.rb
+++ b/app/controllers/admin/seo_controller.rb
@@ -30,7 +30,11 @@ class Admin::SeoController < Admin::BaseController
   private
 
   def settings_params
-    @settings_params ||= params.require(:setting).permit!
+    @settings_params ||= params.require(:setting).permit(settings_keys)
+  end
+
+  def settings_keys
+    @setting.settings_keys + [:custom_permalink]
   end
 
   VALID_SECTIONS = %w(general titles permalinks).freeze


### PR DESCRIPTION
This limits the set of parameters in the Admin::SeoController to the set of valid blog settings, similar to AdminSettingsController. In addition, it allows the extra :custom_permalink key to facilitate the options plus text field construction in the SEO settings form. This eliminates the use of the unsafe #permit! method.