### PR TITLE
Pull in latest changes from 10-0-stable

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -108,7 +108,7 @@ class Admin::ArticlesController < Admin::BaseController
 
     fetch_fresh_or_existing_draft_for_article
 
-    @article.attributes = params[:article].permit!
+    @article.assign_attributes(update_params)
 
     @article.author = current_user
     @article.save_attachments!(params[:attachments])

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -23,7 +23,7 @@ class Admin::NotesController < Admin::BaseController
     note = new_note
 
     note.state = "published"
-    note.attributes = params[:note].permit!
+    note.assign_attributes(note_params)
     note.text_filter ||= default_text_filter
     note.published_at ||= Time.zone.now
     if note.save
@@ -41,7 +41,7 @@ class Admin::NotesController < Admin::BaseController
   end
 
   def update
-    @note.attributes = params[:note].permit!
+    @note.assign_attributes(note_params)
     @note.save
     redirect_to admin_notes_url
   end
@@ -53,6 +53,15 @@ class Admin::NotesController < Admin::BaseController
   end
 
   private
+
+  def note_params
+    params.require(:note).permit(:text_filter_name,
+                                 :body,
+                                 :push_to_twitter,
+                                 :in_reply_to_status_id,
+                                 :permalink,
+                                 :published_at)
+  end
 
   def load_existing_notes
     @notes = Note.page(params[:page]).per(this_blog.limit_article_display)

--- a/app/controllers/admin/seo_controller.rb
+++ b/app/controllers/admin/seo_controller.rb
@@ -30,7 +30,11 @@ class Admin::SeoController < Admin::BaseController
   private
 
   def settings_params
-    @settings_params ||= params.require(:setting).permit!
+    @settings_params ||= params.require(:setting).permit(settings_keys)
+  end
+
+  def settings_keys
+    @setting.settings_keys + [:custom_permalink]
   end
 
   VALID_SECTIONS = %w(general titles permalinks).freeze

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -36,7 +36,7 @@ class Admin::SettingsController < Admin::BaseController
   VALID_ACTIONS = %w(index write feedback display).freeze
 
   def settings_params
-    @settings_params ||= params.require(:setting).permit!
+    @settings_params ||= params.require(:setting).permit(@setting.settings_keys)
   end
 
   def action_param

--- a/app/controllers/admin/sidebar_controller.rb
+++ b/app/controllers/admin/sidebar_controller.rb
@@ -8,9 +8,11 @@ class Admin::SidebarController < Admin::BaseController
 
   # Just update a single active Sidebar instance at once
   def update
-    @sidebar = Sidebar.where(id: params[:id]).first
+    @sidebar = Sidebar.find(params[:id])
     @old_s_index = @sidebar.staged_position || @sidebar.active_position
-    @sidebar.update params[:configure][@sidebar.id.to_s].permit!
+    @sidebar.update params.require(:configure)
+      .require(@sidebar.id.to_s)
+      .permit(@sidebar.fields.map(&:key))
     respond_to do |format|
       format.js
       format.html do

--- a/app/models/config_manager.rb
+++ b/app/models/config_manager.rb
@@ -28,6 +28,10 @@ module ConfigManager
       fields[key.to_s].default
     end
 
+    def settings_keys
+      fields.keys
+    end
+
     private
 
     def add_setting_reader(item)
@@ -63,6 +67,10 @@ module ConfigManager
 
   def canonicalize(key, value)
     self.class.fields[key.to_s].canonicalize(value)
+  end
+
+  def settings_keys
+    self.class.settings_keys
   end
 
   class Item

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -7,112 +7,107 @@ RSpec.describe Admin::NotesController, type: :controller do
 
   let(:admin) { create(:user, :as_admin, twitter: "@getpublify") }
   let!(:blog) { create(:blog, limit_article_display: 10) }
+  let(:note) { create(:note, user_id: admin) }
 
   before do
     sign_in admin
   end
 
-  context "with a blog" do
-    describe "index" do
-      let!(:notes) { create_list(:note, 2) }
+  describe "#index" do
+    let!(:notes) { create_list(:note, 2) }
 
-      it "shows the index template" do
-        get :index
-        expect(response).to render_template("index")
-      end
+    it "shows the index template" do
+      get :index
+      expect(response).to render_template("index")
+    end
 
-      it "lists existing notes" do
-        get :index
-        expect(assigns(:notes)).to match_array notes
-      end
+    it "lists existing notes" do
+      get :index
+      expect(assigns(:notes)).to match_array notes
+    end
 
-      it "assigns a new note for the note form" do
-        get :index
+    it "assigns a new note for the note form" do
+      get :index
 
-        aggregate_failures do
-          expect(assigns(:note)).to be_a(Note)
-          expect(assigns(:note).author).to eq(admin.login)
-          expect(assigns(:note).user).to eq(admin)
-        end
-      end
-
-      it "lists notes without publication date" do
-        create(:note, published_at: nil)
-
-        get :index
-        expect(response).to be_successful
+      aggregate_failures do
+        expect(assigns(:note)).to be_a(Note)
+        expect(assigns(:note).author).to eq(admin.login)
+        expect(assigns(:note).user).to eq(admin)
       end
     end
 
-    describe "create" do
-      context "a simple note" do
-        before { post :create, params: { note: { body: "Emphasis _mine_" } } }
+    it "lists notes without publication date" do
+      create(:note, published_at: nil)
 
-        it { expect(response).to redirect_to(admin_notes_path) }
-        it { expect(flash[:notice]).to eq(I18n.t("notice.note_successfully_created")) }
-      end
+      get :index
+      expect(response).to be_successful
+    end
+  end
 
-      it "creates a note" do
-        expect do
-          post :create, params: { note: { body: "Emphasis _mine_" } }
-        end.to change(Note, :count).from(0).to(1)
-      end
+  describe "#create" do
+    context "a simple note" do
+      before { post :create, params: { note: { body: "Emphasis _mine_" } } }
 
-      context "with twitter access configured" do
-        before do
-          blog.twitter_consumer_key = "consumer_key"
-          blog.twitter_consumer_secret = "consumer_secret"
-          blog.save
-
-          admin.twitter_oauth_token = "oauth_token"
-          admin.twitter_oauth_token_secret = "oauth_token"
-          admin.save
-        end
-
-        it "sends the note to twitter" do
-          expect(Note.count).to eq(0)
-          twitter_cli = double(:twitter_cli)
-          expect(Twitter::Client).to receive(:new).and_return(twitter_cli)
-          tweet = Struct.new(:attrs).new({ id_str: "2344" })
-          expect(twitter_cli).to receive(:update).and_return(tweet)
-          post :create, params: { note: { body: "Emphasis _mine_, arguments *strong*" },
-                                  push_to_twitter: "true" }
-          expect(Note.first.twitter_id).to eq("2344")
-        end
-      end
+      it { expect(response).to redirect_to(admin_notes_path) }
+      it { expect(flash[:notice]).to eq(I18n.t("notice.note_successfully_created")) }
     end
 
-    context "with an existing note from current user" do
-      let(:note) { create(:note, user_id: admin) }
+    it "creates a note" do
+      expect do
+        post :create, params: { note: { body: "Emphasis _mine_" } }
+      end.to change(Note, :count).from(0).to(1)
+    end
 
-      describe "edit" do
-        before { get :edit, params: { id: note.id } }
+    context "with twitter access configured" do
+      before do
+        blog.twitter_consumer_key = "consumer_key"
+        blog.twitter_consumer_secret = "consumer_secret"
+        blog.save
 
-        it { expect(response).to be_successful }
-        it { expect(response).to render_template("edit") }
-        it { expect(assigns(:note)).to eq(note) }
-        it { expect(assigns(:notes)).to eq([note]) }
+        admin.twitter_oauth_token = "oauth_token"
+        admin.twitter_oauth_token_secret = "oauth_token"
+        admin.save
       end
 
-      describe "update" do
-        before { post :update, params: { id: note.id, note: { body: "new body" } } }
-
-        it { expect(response).to redirect_to(action: :index) }
-        it { expect(note.reload.body).to eq("new body") }
-      end
-
-      describe "show" do
-        before { get :show, params: { id: note.id } }
-
-        it { expect(response).to render_template("show") }
-      end
-
-      describe "Destroying a note" do
-        before { post :destroy, params: { id: note.id } }
-
-        it { expect(response).to redirect_to(admin_notes_path) }
-        it { expect(Note.count).to eq(0) }
+      it "sends the note to twitter" do
+        expect(Note.count).to eq(0)
+        twitter_cli = double(:twitter_cli)
+        expect(Twitter::Client).to receive(:new).and_return(twitter_cli)
+        tweet = Struct.new(:attrs).new({ id_str: "2344" })
+        expect(twitter_cli).to receive(:update).and_return(tweet)
+        post :create, params: { note: { body: "Emphasis _mine_, arguments *strong*" },
+                                push_to_twitter: "true" }
+        expect(Note.first.twitter_id).to eq("2344")
       end
     end
+  end
+
+  describe "#edit" do
+    before { get :edit, params: { id: note.id } }
+
+    it { expect(response).to be_successful }
+    it { expect(response).to render_template("edit") }
+    it { expect(assigns(:note)).to eq(note) }
+    it { expect(assigns(:notes)).to eq([note]) }
+  end
+
+  describe "#update" do
+    before { post :update, params: { id: note.id, note: { body: "new body" } } }
+
+    it { expect(response).to redirect_to(action: :index) }
+    it { expect(note.reload.body).to eq("new body") }
+  end
+
+  describe "#show" do
+    before { get :show, params: { id: note.id } }
+
+    it { expect(response).to render_template("show") }
+  end
+
+  describe "#destroy" do
+    before { post :destroy, params: { id: note.id } }
+
+    it { expect(response).to redirect_to(admin_notes_path) }
+    it { expect(Note.count).to eq(0) }
   end
 end


### PR DESCRIPTION
- **Limit accepted parameters for Sidebar update in Admin**
- **Use known set of allowed attributes when autosaving an Article**
- **Permit only valid settings keys when updating blog settings**
- **Use default describe blocks for Admin::NotesController specs**
- **Limit assigned attributes when creating and updating Notes**
- **Limit allowed SEO settings params**
