### PR TITLE
Upgrade to commonmarker version 2.3

### DIFF
--- a/app/models/content_base.rb
+++ b/app/models/content_base.rb
@@ -33,7 +33,7 @@ module ContentBase
   # Generate HTML for a specific field using the text_filter in use for this
   # object.
   def generate_html(field, text = nil)
-    text ||= self[field].to_s
+    text ||= self[field] || ""
     html = (text_filter || default_text_filter).filter_text(text) || text
     html_postprocess(field, html).to_s
   end

--- a/app/models/text_filter.rb
+++ b/app/models/text_filter.rb
@@ -44,7 +44,7 @@ class TextFilter
       if f.help_text.blank?
         ""
       else
-        "<h3>#{f.display_name}</h3>\n#{CommonMarker.render_html(f.help_text, :DEFAULT)}"
+        "<h3>#{f.display_name}</h3>\n#{Commonmarker.to_html(f.help_text)}"
       end
     end
 
@@ -56,7 +56,7 @@ class TextFilter
       .expand_filter_list([markup, filters].flatten)
 
     help_filters.map do |f|
-      f.help_text.blank? ? "" : CommonMarker.render_html(f.help_text)
+      f.help_text.blank? ? "" : Commonmarker.to_html(f.help_text)
     end.join("\n")
   end
 

--- a/lib/publify_core/text_filter/markdown.rb
+++ b/lib/publify_core/text_filter/markdown.rb
@@ -46,7 +46,11 @@ module PublifyCore::TextFilter
     def self.filtertext(text)
       # FIXME: Workaround for <publify:foo> not being interpreted as an HTML tag.
       escaped_macros = text.gsub(%r{(</?publify):}, '\1X')
-      html = CommonMarker.render_html(escaped_macros, :UNSAFE)
+      html = Commonmarker.to_html(escaped_macros,
+                                  options: {
+                                    extension: { header_ids: nil },
+                                    render: { unsafe: true }
+                                  })
       html.gsub(%r{(</?publify)X}, '\1:').strip
     end
   end

--- a/lib/publify_core/text_filter/markdown_smartquotes.rb
+++ b/lib/publify_core/text_filter/markdown_smartquotes.rb
@@ -13,7 +13,12 @@ module PublifyCore::TextFilter
     def self.filtertext(text)
       # FIXME: Workaround for <publify:foo> not being interpreted as an HTML tag.
       escaped_macros = text.gsub(%r{(</?publify):}, '\1X')
-      html = CommonMarker.render_doc(escaped_macros, :SMART).to_html(:UNSAFE)
+      html = Commonmarker.to_html(escaped_macros,
+                                  options: {
+                                    parse: { smart: true },
+                                    extension: { header_ids: nil },
+                                    render: { unsafe: true }
+                                  })
       html.gsub(%r{(</?publify)X}, '\1:').strip
     end
   end

--- a/publify_core.gemspec
+++ b/publify_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "bootstrap", "~> 4.6.2"
   s.add_dependency "cancancan", "~> 3.0"
   s.add_dependency "carrierwave", "~> 3.0"
-  s.add_dependency "commonmarker", "~> 0.23.2"
+  s.add_dependency "commonmarker", "~> 2.3"
   s.add_dependency "devise", ">= 4.8", "< 4.10"
   s.add_dependency "devise-i18n", "~> 1.2"
   s.add_dependency "devise_zxcvbn", "~> 6.0"


### PR DESCRIPTION
- Update commonmarker dependency to ~> 2.3
- Adjust code to changes in commonmarker's API
- Avoid using `nil.to_s` since that returns an String with ASCII encoding which commonmarker doesn't accept
