### PR TITLE
Remove obsolete before_action

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,7 +5,6 @@ class ArticlesController < ContentController
 
   before_action :login_required, only: [:preview, :preview_page]
   before_action :verify_config
-  before_action :auto_discovery_feed, only: [:show, :index]
 
   layout :theme_layout, except: [:trackback]
 


### PR DESCRIPTION
This method is called directly were needed, and the show action does not
exist in this controller.
