### PR TITLE
Remove exceptions from login_required before_action

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -9,7 +9,7 @@ class Admin::BaseController < BaseController
   @@look_for_migrations = true
   layout "administration"
 
-  before_action :login_required, except: [:login, :signup]
+  before_action :login_required
   before_action :no_caching
 
   private


### PR DESCRIPTION
Logging in and signing up are not implemented in the Admin section itself.
