### PR TITLE
Set explicit coder for serialized attributes

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,7 +8,7 @@ class Article < Content
   include PublifyGuid
   include ConfigManager
 
-  serialize :settings, Hash
+  serialize :settings, Hash, coder: YAML
 
   content_fields :body, :extended
 

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -32,7 +32,7 @@ class Blog < ApplicationRecord
 
   validates :blog_name, presence: true
 
-  serialize :settings, Hash
+  serialize :settings, Hash, coder: YAML
 
   # Description
   setting :blog_name, :string, "My Shiny Weblog!"

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -39,7 +39,7 @@ class Content < ApplicationRecord
                               where(published_at: PublifyTime.delta_like(date_at))
                             }
 
-  serialize :whiteboard
+  serialize :whiteboard, coder: YAML
 
   validates_default_string_length :title, :author, :permalink, :name,
                                   :post_type, :text_filter_name

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -7,7 +7,7 @@ class Note < Content
   include PublifyGuid
   include ConfigManager
 
-  serialize :settings, Hash
+  serialize :settings, Hash, coder: YAML
 
   setting :twitter_id, :string, ""
   setting :in_reply_to_status_id, :string, ""

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,7 +6,7 @@ class Page < Content
 
   include ConfigManager
 
-  serialize :settings, Hash
+  serialize :settings, Hash, coder: YAML
   setting :password, :string, ""
 
   before_save :set_permalink

--- a/app/models/sidebar.rb
+++ b/app/models/sidebar.rb
@@ -4,7 +4,7 @@ require "sidebar_field"
 
 # This class cannot be autoloaded since other sidebar classes depend on it.
 class Sidebar < ApplicationRecord
-  serialize :config, Hash
+  serialize :config, Hash, coder: YAML
 
   belongs_to :blog
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
 
   has_many :articles
 
-  serialize :settings, Hash
+  serialize :settings, Hash, coder: YAML
 
   STATUS = %w(active inactive).freeze
 

--- a/db/migrate/20160605154632_remove_profiles.rb
+++ b/db/migrate/20160605154632_remove_profiles.rb
@@ -2,7 +2,7 @@
 
 class RemoveProfiles < ActiveRecord::Migration[4.2]
   class Profile < ActiveRecord::Base
-    serialize :modules
+    serialize :modules, coder: YAML
   end
 
   def up

--- a/db/migrate/20190208152646_move_text_filter_to_name.rb
+++ b/db/migrate/20190208152646_move_text_filter_to_name.rb
@@ -19,8 +19,8 @@ class MoveTextFilterToName < ActiveRecord::Migration[5.2]
   end
 
   class TextFilter < ActiveRecord::Base
-    serialize :filters, Array
-    serialize :params, Hash
+    serialize :filters, Array, coder: YAML
+    serialize :params, Hash, coder: YAML
   end
 
   def up


### PR DESCRIPTION
Setting the coder is required by default in Rails 7.1.
