### PR TITLE
Replace devise_zxcvbn with direct integration of zxcvbn

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,11 +8,12 @@ class User < ApplicationRecord
   ADMIN = "admin"
   PUBLISHER = "publisher"
   CONTRIBUTOR = "contributor"
+  MIN_PASSWORD_SCORE = 4
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :zxcvbnable
+         :recoverable, :rememberable, :trackable, :validatable
   include ConfigManager
   include StringLengthLimit
 
@@ -23,6 +24,7 @@ class User < ApplicationRecord
   validates :login, length: { in: 3..40 }
   validates_default_string_length :email, :text_filter_name
   validates :name, length: { maximum: 2048 }
+  validate :strong_password, if: :password_required?
 
   belongs_to :resource, optional: true
   has_many :notifications, foreign_key: "notify_user_id"
@@ -137,6 +139,13 @@ class User < ApplicationRecord
   end
 
   private
+
+  def strong_password
+    return if password.blank?
+
+    test = Zxcvbn.test(password)
+    errors.add :password, :weak_password if test.score < MIN_PASSWORD_SCORE
+  end
 
   def set_default_profile
     self.profile ||= User.none? ? "admin" : "contributor"

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -19,6 +19,8 @@ ar:
           attributes:
             title:
               blank: لا يمكن تركها فارغة
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -19,6 +19,8 @@ da:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -19,6 +19,8 @@ de:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -19,6 +19,8 @@ es-MX:
           attributes:
             title:
               blank: no puede ser vac&iacute;o
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -19,6 +19,8 @@ fr:
           attributes:
             title:
               blank: ne peut être laissé vide
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -19,6 +19,8 @@ he:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -19,6 +19,8 @@ it:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,8 @@ ja:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -19,6 +19,8 @@ lt:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -19,6 +19,8 @@ nb:
           attributes:
             title:
               blank: kan ikke være blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -19,6 +19,8 @@ nl:
           attributes:
             title:
               blank: mag niet leeg zijn
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -19,6 +19,8 @@ pl:
           attributes:
             title:
               blank: nie może być puste
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -19,6 +19,8 @@ pt-BR:
           attributes:
             title:
               blank: não pode ser vazio
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -19,6 +19,8 @@ ro:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -19,6 +19,8 @@ ru:
           attributes:
             title:
               blank: не может быть пустым
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -19,6 +19,8 @@ zh-CN:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -19,6 +19,8 @@ zh-TW:
           attributes:
             title:
               blank: can't be blank
+        user:
+          weak_password: is too weak
   admin:
     articles:
       access_granted:

--- a/lib/publify_core.rb
+++ b/lib/publify_core.rb
@@ -2,7 +2,6 @@
 
 require "devise"
 require "devise-i18n"
-require "devise_zxcvbn"
 
 require "publify_core/version"
 require "publify_core/engine"
@@ -23,6 +22,7 @@ require "rails-i18n"
 require "rails-timeago"
 require "recaptcha/rails"
 require "sassc-rails"
+require "zxcvbn"
 
 require "email_notify"
 require "publify_guid"

--- a/publify_core.gemspec
+++ b/publify_core.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency "commonmarker", "~> 2.3"
   s.add_dependency "devise", ">= 4.8", "< 4.10"
   s.add_dependency "devise-i18n", "~> 1.2"
-  s.add_dependency "devise_zxcvbn", "~> 6.0"
   s.add_dependency "fog-aws", "~> 3.2"
   s.add_dependency "fog-core", "~> 2.2"
   s.add_dependency "html-pipeline", "~> 3.2"
@@ -48,6 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sassc-rails", "~> 2.0"
   s.add_dependency "twitter", ">= 7.0", "< 8.3"
   s.add_dependency "uuidtools", ">= 2.2", "< 3.1"
+  s.add_dependency "zxcvbn", "~> 1.0"
 
   s.add_development_dependency "appraisal", "~> 2.3"
   s.add_development_dependency "capybara", "~> 3.0"

--- a/spec/features/setup_spec.rb
+++ b/spec/features/setup_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Blog setup", type: :feature do
     click_button I18n.t!("generic.save")
 
     expect(page)
-      .to have_text "Password not strong enough. It scored 2. It must score at least 4."
+      .to have_text "Password is too weak"
 
     fill_in :user_password, with: strong_password
     click_button I18n.t!("generic.save")


### PR DESCRIPTION
The `devise_zxcvbn` gem depends on an older version of `zxcvbn` and needlessly requires `ostruct`. A new release is pending but there is no activity.

This change replaces the `devise_zxcvbn` integration with a validator on the `User` model.
