### PR TITLE
Remove monkey-patched String#strip_html method

### DIFF
--- a/app/helpers/xml_helper.rb
+++ b/app/helpers/xml_helper.rb
@@ -15,4 +15,8 @@ module XmlHelper
       times.max.xmlschema
     end
   end
+
+  def truncated_body(item)
+    truncate(strip_tags(item.html(:body)), length: 80, separator: " ", omissions: "...")
+  end
 end

--- a/app/models/content_base.rb
+++ b/app/models/content_base.rb
@@ -3,6 +3,7 @@
 module ContentBase
   def self.included(base)
     base.extend ClassMethods
+    base.include ActionView::Helpers::SanitizeHelper
   end
 
   attr_accessor :just_changed_published_status
@@ -49,13 +50,13 @@ module ContentBase
   end
 
   def excerpt_text(length = 160)
-    text = if respond_to?(:excerpt) && (excerpt || "") != ""
+    text = if respond_to?(:excerpt) && excerpt.present?
              generate_html(:excerpt, excerpt)
            else
              html(:all)
            end
 
-    text = text.strip_html
+    text = strip_tags(text)
 
     text.slice(0, length) +
       (text.length > length ? "..." : "")

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -10,6 +10,8 @@ class Note < Content
   include PublifyGuid
   include ConfigManager
 
+  include ActionView::Helpers::SanitizeHelper
+
   serialize :settings, type: Hash, coder: YAML
 
   setting :twitter_id, :string, ""
@@ -122,7 +124,7 @@ class Note < Content
   end
 
   def twitter_message
-    base_message = body.strip_html
+    base_message = strip_tags(body)
     if too_long?("#{base_message} (#{short_link})")
       max_length = 140 - "... (#{redirect.from_url})".length - 1
       "#{truncate(base_message, max_length)}... (#{redirect.from_url})"

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -10,8 +10,6 @@ class Note < Content
   include PublifyGuid
   include ConfigManager
 
-  include ActionView::Helpers::SanitizeHelper
-
   serialize :settings, type: Hash, coder: YAML
 
   setting :twitter_id, :string, ""

--- a/app/views/admin/dashboard/_comment.html.erb
+++ b/app/views/admin/dashboard/_comment.html.erb
@@ -9,7 +9,7 @@
       <%= display_date_and_time comment.created_at %>
     </h5>
     <p>
-    <%= comment.html.strip_html.slice(0..300) %>
+    <%= comment.excerpt_text(300) %>
     </p>
     <%= button_to_conversation(comment) %>
     <hr>

--- a/app/views/admin/dashboard/_drafts.html.erb
+++ b/app/views/admin/dashboard/_drafts.html.erb
@@ -13,7 +13,7 @@
             <%= link_to(post.title, controller: 'admin/articles', action: 'edit', id: post.id) %>
             <%= display_date_and_time(post.created_at) %>
           </h5>
-          <p><%= post.body&.strip_html&.slice(0, 300) %></p>
+          <p><%= post.excerpt_text(300) %></p>
           <hr>
           </li>
         <% end %>

--- a/app/views/admin/notes/_note.html.erb
+++ b/app/views/admin/notes/_note.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td>
-    <%= h(note.body.strip_html.slice(0..140)) %>
+    <%= note.excerpt_text(140) %>
   </td>
   <td>
     <%= author_link(note) %><br>

--- a/app/views/shared/_atom_item_article.atom.builder
+++ b/app/views/shared/_atom_item_article.atom.builder
@@ -7,9 +7,7 @@ feed.entry(item, id: "urn:uuid:#{item.guid}", published: item.published_at,
   end
 
   if item.is_a?(Note)
-    truncated_body = truncate(item.html(:body).strip_html,
-                              length: 80, separator: " ", omissions: "...")
-    entry.title truncated_body, "type" => "html"
+    entry.title truncated_body(item), "type" => "html"
   else
     entry.title item.title, "type" => "html"
   end

--- a/app/views/shared/_rss_item_article.rss.builder
+++ b/app/views/shared/_rss_item_article.rss.builder
@@ -2,8 +2,7 @@
 
 xm.item do
   if item.is_a?(Note)
-    xm.title truncate(item.html(:body).strip_html, length: 80, separator: " ",
-                                                   omissions: "...")
+    xm.title truncated_body(item)
   else
     xm.title item.title
   end

--- a/lib/publify_core/string_ext.rb
+++ b/lib/publify_core/string_ext.rb
@@ -34,17 +34,6 @@ module PublifyCore
     def to_title(item, settings, params)
       TitleBuilder.new(self).build(item, settings, params)
     end
-
-    # Strips any html markup from a string
-    TYPO_TAG_KEY = TYPO_ATTRIBUTE_KEY = /[\w:_-]+/
-    TYPO_ATTRIBUTE_VALUE = /(?:[A-Za-z0-9]+|(?:'[^']*?'|"[^"]*?"))/
-    TYPO_ATTRIBUTE = /(?:#{TYPO_ATTRIBUTE_KEY}(?:\s*=\s*#{TYPO_ATTRIBUTE_VALUE})?)/
-    TYPO_ATTRIBUTES = /(?:#{TYPO_ATTRIBUTE}(?:\s+#{TYPO_ATTRIBUTE})*)/
-    TAG = %r{<[!/?\[]?(?:#{TYPO_TAG_KEY}|--)(?:\s+#{TYPO_ATTRIBUTES})?\s*(?:[!/?\]]+|--)?>}
-
-    def strip_html
-      gsub(TAG, "").gsub(/\s+/, " ").strip
-    end
   end
 end
 

--- a/spec/publify_core/string_ext_spec.rb
+++ b/spec/publify_core/string_ext_spec.rb
@@ -15,14 +15,4 @@ RSpec.describe PublifyCore::StringExt do
       expect(" this is  a sentence ".to_url).to eq("this-is-a-sentence")
     end
   end
-
-  describe "strip_html" do
-    it "renders text only" do
-      expect("<a href='http://myblog.com'>my blog</a>".strip_html).to eq("my blog")
-    end
-
-    it "does not remove a > from a numeric comparison" do
-      expect("5 < 6 > 4".strip_html).to eq("5 < 6 > 4")
-    end
-  end
 end


### PR DESCRIPTION
- **Replace use of StringExt#strip_html with #strip_tags in feed templates**
- **Replace use of StringExt#strip_html with #strip_tags in Note#twitter_message**
- **Replace use of StringExt#strip_html with #strip_tags in ContentBase#excerpt_text**
- **Use ContentBase#excerpt_text for excerpts in admin**
- **Remove StringExt#strip_html and supporting constants**
