### PR TITLE
Clean up textfilter macro methods

### DIFF
--- a/lib/text_filter_plugin.rb
+++ b/lib/text_filter_plugin.rb
@@ -141,8 +141,8 @@ module TextFilterPlugin::MacroMethods
       macrofilter(attributes_parse(match))
     end
 
-    new_text.gsub(regex2) do |_match|
-      macrofilter(attributes_parse(Regexp.last_match[1].to_s), Regexp.last_match[2].to_s)
+    new_text.gsub(regex2) do |match|
+      macrofilter(attributes_parse(match), Regexp.last_match[2].to_s)
     end
   end
 
@@ -152,22 +152,10 @@ module TextFilterPlugin::MacroMethods
 
   private
 
-  # Utility function -- hand it a XML string like <a href="foo" title="bar">
-  # and it'll give you back { "href" => "foo", "title" => "bar" }
+  # Return a hash of attributes of the HMTL element represented by string
   def attributes_parse(string)
-    attributes = {}
-
-    string.gsub(/([^ =]+="[^"]*")/) do |match|
-      key, value = match.split("=", 2)
-      attributes[key] = value.delete('"')
-    end
-
-    string.gsub(/([^ =]+='[^']*')/) do |match|
-      key, value = match.split("=", 2)
-      attributes[key] = value.delete("'")
-    end
-
-    attributes
+    elem = Nokogiri::HTML5.fragment(string).children.first
+    elem.attribute_nodes.to_h { [_1.name, _1.value] }
   end
 end
 

--- a/lib/text_filter_plugin.rb
+++ b/lib/text_filter_plugin.rb
@@ -118,6 +118,10 @@ class TextFilterPlugin
   def self.abstract_filter!
     @@filter_map.delete short_name
   end
+
+  def self.filtertext(_text)
+    raise NotImplementedError, "Must be implemented by subclasses"
+  end
 end
 
 class TextFilterPlugin::PostProcess < TextFilterPlugin
@@ -129,6 +133,25 @@ class TextFilterPlugin::PostProcess < TextFilterPlugin
 end
 
 module TextFilterPlugin::MacroMethods
+  def filtertext(text)
+    regex1 = %r{<publify:#{short_name}(?:[ \t][^>]*)?/>}
+    regex2 = %r{<publify:#{short_name}([ \t][^>]*)?>(.*?)</publify:#{short_name}>}m
+
+    new_text = text.gsub(regex1) do |match|
+      macrofilter(attributes_parse(match))
+    end
+
+    new_text.gsub(regex2) do |_match|
+      macrofilter(attributes_parse(Regexp.last_match[1].to_s), Regexp.last_match[2].to_s)
+    end
+  end
+
+  def macrofilter(...)
+    raise NotImplementedError, "Must be implemented by subclasses"
+  end
+
+  private
+
   # Utility function -- hand it a XML string like <a href="foo" title="bar">
   # and it'll give you back { "href" => "foo", "title" => "bar" }
   def attributes_parse(string)
@@ -145,19 +168,6 @@ module TextFilterPlugin::MacroMethods
     end
 
     attributes
-  end
-
-  def filtertext(text)
-    regex1 = %r{<publify:#{short_name}(?:[ \t][^>]*)?/>}
-    regex2 = %r{<publify:#{short_name}([ \t][^>]*)?>(.*?)</publify:#{short_name}>}m
-
-    new_text = text.gsub(regex1) do |match|
-      macrofilter(attributes_parse(match))
-    end
-
-    new_text.gsub(regex2) do |_match|
-      macrofilter(attributes_parse(Regexp.last_match[1].to_s), Regexp.last_match[2].to_s)
-    end
   end
 end
 

--- a/spec/lib/text_filter_plugin_spec.rb
+++ b/spec/lib/text_filter_plugin_spec.rb
@@ -19,22 +19,43 @@ RSpec.describe TextFilterPlugin do
     end
   end
 
-  shared_examples "a macro class" do
-    describe ".attributes_parse" do
-      it 'parses lang="ruby" to {"lang" => "ruby"}' do
-        expect(described_class.attributes_parse('<publify:code lang="ruby">'))
-          .to eq("lang" => "ruby")
+  shared_examples "an abstract macro class" do
+    describe ".filtertext" do
+      before do
+        allow(described_class).to receive(:macrofilter) do |attrs, content = nil|
+          content ||= "NO CONTENT"
+          attrs_text = attrs.map { |key, val| "#{key}=#{val}" }.join(", ")
+          "#{attrs_text} (#{content})"
+        end
+        allow(described_class).to receive(:short_name).and_return "code"
       end
 
-      it "parses lang='ruby' to {'lang' => 'ruby'}" do
-        expect(described_class.attributes_parse("<publify:code lang='ruby'>"))
-          .to eq("lang" => "ruby")
+      it "parses contentless tags with double-quoted attribute values" do
+        expect(described_class.filtertext("<publify:code lang=\"ruby\"/>"))
+          .to eq("lang=ruby (NO CONTENT)")
+      end
+
+      it "parses contentless tags with single-quoted attribute values" do
+        expect(described_class.filtertext("<publify:code lang='ruby'/>"))
+          .to eq("lang=ruby (NO CONTENT)")
+      end
+
+      it "parses contentful tags with double-quoted attribute values" do
+        result = described_class
+          .filtertext("<publify:code lang=\"ruby\">puts \"hi!\"</publify:code>")
+        expect(result).to eq("lang=ruby (puts \"hi!\")")
+      end
+
+      it "parses contentful tags with single-quoted attribute values" do
+        result = described_class
+          .filtertext("<publify:code lang='ruby'>puts \"hi!\"</publify:code>")
+        expect(result).to eq("lang=ruby (puts \"hi!\")")
       end
     end
   end
 
   describe described_class::MacroPre do
-    it_behaves_like "a macro class"
+    it_behaves_like "an abstract macro class"
 
     it "declares itself to be a macropre filter" do
       expect(described_class.filter_type).to eq "macropre"
@@ -42,7 +63,7 @@ RSpec.describe TextFilterPlugin do
   end
 
   describe described_class::MacroPost do
-    it_behaves_like "a macro class"
+    it_behaves_like "an abstract macro class"
 
     it "declares itself to be a macropost filter" do
       expect(described_class.filter_type).to eq "macropost"


### PR DESCRIPTION
Limits public interface and cleans up attribute parser

- **Test TextFilter::MacroMethods only through its intended public interface**
- **Use Nokogiri to safely parse attributes for macro text filters**
