### PR TITLE
Simplife derivation of a theme's name from its path

### DIFF
--- a/lib/theme.rb
+++ b/lib/theme.rb
@@ -67,7 +67,7 @@ class Theme
   end
 
   def self.theme_from_path(path)
-    name = path.scan(/[-\w]+$/i).flatten.first
+    name = File.basename(path)
     new(name, path)
   end
 


### PR DESCRIPTION
The existing regex basically returned the path's basename, except it would fail if the basename included non-word characters (except the dash).

Using just File.basename simplifies this. Accepting more theme names seems fine.
