### PR TITLE
Remove translation only used in Typographic theme

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -46,6 +46,5 @@ ignore_missing:
 ## Consider these keys used:
 ignore_unused:
   - 'time.formats.*'
-  - 'layouts.default.designed_by'
   - 'date.*'
   - 'activerecord.errors.models.*'

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -845,7 +845,6 @@ ar:
     administration:
       powered_by: بفخر تُشغل بواسطة
     default:
-      designed_by: صُممت بواسطة %{designed_by}
       powered_by_html: مشغل بواسطة %{powered_by}
   notes:
     note:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -812,7 +812,6 @@ da:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -816,7 +816,6 @@ de:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -811,7 +811,6 @@ en:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -814,7 +814,6 @@ es-MX:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -829,7 +829,6 @@ fr:
     administration:
       powered_by: Tourne fièrement sous
     default:
-      designed_by: Design par %{designed_by}
       powered_by_html: Propulsé par %{powered_by}
   notes:
     note:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -807,7 +807,6 @@ he:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: עוצב על ידי %{designed_by}
       powered_by_html: מופעל על ידי %{powered_by}
   notes:
     note:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -813,7 +813,6 @@ it:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -795,7 +795,6 @@ ja:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -828,7 +828,6 @@ lt:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -807,7 +807,6 @@ nb:
     administration:
       powered_by: drives stolt av
     default:
-      designed_by: Utformet av %{designed_by}
       powered_by_html: Drives av %{powered_by}
   notes:
     note:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -815,7 +815,6 @@ nl:
     administration:
       powered_by: wordt trots aangedreven door
     default:
-      designed_by: Ontworpen door %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -840,7 +840,6 @@ pl:
     administration:
       powered_by: dumnie działa na
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -815,7 +815,6 @@ pt-BR:
     administration:
       powered_by: é orgulhosamente desenvolvido por
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -827,7 +827,6 @@ ro:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -841,7 +841,6 @@ ru:
     administration:
       powered_by: с гордостью работает на
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -796,7 +796,6 @@ zh-CN:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -797,7 +797,6 @@ zh-TW:
     administration:
       powered_by: is proudly powered by
     default:
-      designed_by: Designed by %{designed_by}
       powered_by_html: Powered by %{powered_by}
   notes:
     note:


### PR DESCRIPTION
In future, themes will have to provide any needed translations.
